### PR TITLE
Expand Ship Configurations to 8 Traveller SRD options

### DIFF
--- a/app/src/androidTest/java/starship/virtualsoundnw/com/ui/starship/StarShipScreenTest.kt
+++ b/app/src/androidTest/java/starship/virtualsoundnw/com/ui/starship/StarShipScreenTest.kt
@@ -55,7 +55,7 @@ class StarShipScreenTest {
         composeTestRule.onNodeWithText("Description").assertExists() 
         composeTestRule.onNodeWithText("Tonnage").assertExists()
         composeTestRule.onNodeWithText("Tech Level: C").assertExists()
-        composeTestRule.onNodeWithText("Configuration: STANDARD").assertExists()
+        composeTestRule.onNodeWithText("Configuration: Standard (Cylinder)").assertExists()
     }
 
     @Test
@@ -74,5 +74,5 @@ class StarShipScreenTest {
 
 private val FAKE_DATA = listOf(
     StarShip("Enterprise", "Constitution class", 200, TechLevel.G, Configuration.STANDARD),
-    StarShip("Voyager", "Intrepid class", 300, TechLevel.H, Configuration.DISTRIBUTED)
+    StarShip("Voyager", "Intrepid class", 300, TechLevel.H, Configuration.SPHERE)
 )

--- a/app/src/main/java/starship/virtualsoundnw/com/data/di/DataModule.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/di/DataModule.kt
@@ -51,6 +51,6 @@ class FakeStarShipRepository @Inject constructor() : StarShipRepository {
 
 val fakeStarShips = listOf(
     StarShip("One", "First test ship", 200, TechLevel.C, Configuration.STANDARD),
-    StarShip("Two", "Second test ship", 400, TechLevel.E, Configuration.STREAMLINED),
-    StarShip("Three", "Third test ship", 600, TechLevel.G, Configuration.DISTRIBUTED)
+    StarShip("Two", "Second test ship", 400, TechLevel.E, Configuration.NEEDLE_WEDGE),
+    StarShip("Three", "Third test ship", 600, TechLevel.G, Configuration.SPHERE)
 )

--- a/app/src/main/java/starship/virtualsoundnw/com/data/local/database/StarShip.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/local/database/StarShip.kt
@@ -28,7 +28,14 @@ enum class TechLevel {
 }
 
 enum class Configuration {
-    STANDARD, STREAMLINED, DISTRIBUTED
+    NEEDLE_WEDGE,
+    CONE,
+    STANDARD,
+    CLOSE_STRUCTURE,
+    SPHERE,
+    DISPERSED_STRUCTURE,
+    PLANETOID,
+    BUFFERED_PLANETOID
 }
 
 @Entity

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/starship/StarShipScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/starship/StarShipScreen.kt
@@ -198,7 +198,7 @@ private fun ShipInputForm(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text("Configuration: $configuration")
+                    Text("Configuration: ${configuration.displayName()}")
                     Text("▼")
                 }
             }
@@ -208,7 +208,7 @@ private fun ShipInputForm(
             ) {
                 Configuration.entries.forEach { config ->
                     DropdownMenuItem(
-                        text = { Text(config.name.lowercase().replaceFirstChar { it.uppercase() }) },
+                        text = { Text(config.displayName()) },
                         onClick = {
                             configuration = config
                             configurationDropdownExpanded = false
@@ -255,7 +255,7 @@ private fun DefaultPreview() {
         StarShipScreen(
             items = listOf(
                 StarShip("Enterprise", "Constitution class", 200, TechLevel.G, Configuration.STANDARD),
-                StarShip("Millennium Falcon", "Modified freighter", 400, TechLevel.E, Configuration.STREAMLINED)
+                StarShip("Millennium Falcon", "Modified freighter", 400, TechLevel.E, Configuration.NEEDLE_WEDGE)
             ),
             onSave = {}
         )
@@ -268,9 +268,21 @@ private fun PortraitPreview() {
     MyApplicationTheme {
         StarShipScreen(
             items = listOf(
-                StarShip("Voyager", "Intrepid class", 300, TechLevel.H, Configuration.DISTRIBUTED)
+                StarShip("Voyager", "Intrepid class", 300, TechLevel.H, Configuration.SPHERE)
             ),
             onSave = {}
         )
     }
+}
+
+// Extension function to display user-friendly configuration names
+private fun Configuration.displayName(): String = when (this) {
+    Configuration.NEEDLE_WEDGE -> "Needle/Wedge"
+    Configuration.CONE -> "Cone"
+    Configuration.STANDARD -> "Standard (Cylinder)"
+    Configuration.CLOSE_STRUCTURE -> "Close Structure"
+    Configuration.SPHERE -> "Sphere"
+    Configuration.DISPERSED_STRUCTURE -> "Dispersed Structure"
+    Configuration.PLANETOID -> "Planetoid"
+    Configuration.BUFFERED_PLANETOID -> "Buffered Planetoid"
 }


### PR DESCRIPTION
## Summary
- Implements issue #27: Add more Ship Configurations
- Expands from 3 configurations to 8 comprehensive Traveller SRD compliant options
- Adds user-friendly display names for better UI experience

## Changes
- **StarShip.kt**: Updated Configuration enum with 8 new options
- **StarShipScreen.kt**: Added displayName() extension function for user-friendly names
- **DataModule.kt**: Updated fake test data to use new configurations  
- **StarShipScreenTest.kt**: Updated UI tests for new configuration display format

## Ship Configurations
Expanded from 3 to 8 Traveller SRD configurations:
1. **Needle/Wedge** - Streamlined design for high-speed operations
2. **Cone** - Aerodynamic cone configuration
3. **Standard (Cylinder)** - Traditional cylindrical hull design
4. **Close Structure** - Compact structural configuration
5. **Sphere** - Spherical hull design
6. **Dispersed Structure** - Distributed component layout
7. **Planetoid** - Irregular planetoid-shaped hull
8. **Buffered Planetoid** - Protected planetoid configuration

## UI Enhancements
- Configuration dropdown now shows user-friendly names
- Button displays proper names like "Needle/Wedge" instead of "NEEDLE_WEDGE"
- All 8 configurations available in selector dropdown

## Test plan
- [x] All 8 configurations display correctly in UI dropdown
- [x] Configuration names show user-friendly format
- [x] Updated test data uses new configuration options
- [x] All unit tests pass with expanded enum
- [x] UI tests verify new display format

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)