### PR TITLE
Add transition to Fittings screen when required engines are configured

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
@@ -27,6 +27,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import starship.virtualsoundnw.com.ui.starship.StarShipScreen
 import starship.virtualsoundnw.com.ui.engines.EnginesScreen
+import starship.virtualsoundnw.com.ui.fittings.FittingsScreen
 
 @Composable
 fun MainNavigation() {
@@ -44,6 +45,16 @@ fun MainNavigation() {
         composable("engines/{shipId}") { backStackEntry ->
             val shipId = backStackEntry.arguments?.getString("shipId")?.toIntOrNull() ?: -1
             EnginesScreen(
+                shipId = shipId,
+                modifier = Modifier.padding(16.dp),
+                onNavigateToFittings = { shipId ->
+                    navController.navigate("fittings/$shipId")
+                }
+            )
+        }
+        composable("fittings/{shipId}") { backStackEntry ->
+            val shipId = backStackEntry.arguments?.getString("shipId")?.toIntOrNull() ?: -1
+            FittingsScreen(
                 shipId = shipId,
                 modifier = Modifier.padding(16.dp)
             )

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
@@ -72,7 +73,8 @@ import kotlin.math.roundToInt
 fun EnginesScreen(
     shipId: Int,
     modifier: Modifier = Modifier,
-    viewModel: EnginesViewModel = hiltViewModel()
+    viewModel: EnginesViewModel = hiltViewModel(),
+    onNavigateToFittings: (Int) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -161,6 +163,18 @@ fun EnginesScreen(
                             ship = ship,
                             uiState = uiState
                         )
+                    }
+                    
+                    // Next: Fittings button when requirements are met
+                    if (uiState.hasRequiredEngines()) {
+                        item {
+                            Button(
+                                onClick = { onNavigateToFittings(shipId) },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text("Next: Fittings")
+                            }
+                        }
                     }
                 }
             }
@@ -675,6 +689,18 @@ private fun EnginesScreenPreview() {
                     ship = sampleShip,
                     uiState = uiState
                 )
+            }
+            
+            // Next: Fittings button when requirements are met
+            if (uiState.hasRequiredEngines()) {
+                item {
+                    Button(
+                        onClick = { },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Next: Fittings")
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
@@ -93,6 +93,14 @@ data class EnginesUiState(
     fun isCapitalShip(): Boolean {
         return ship?.isCapitalShip ?: false
     }
+    
+    /**
+     * Check if ship has required engines to proceed to fittings
+     * Requires at least 1 power plant and 1 jump drive
+     */
+    fun hasRequiredEngines(): Boolean {
+        return powerPlants.isNotEmpty() && jumpDrives.isNotEmpty()
+    }
 }
 
 @HiltViewModel

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
@@ -32,11 +32,53 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import starship.virtualsoundnw.com.data.local.database.Configuration
+import starship.virtualsoundnw.com.data.local.database.StarShip
+import starship.virtualsoundnw.com.data.local.database.TechLevel
+import starship.virtualsoundnw.com.ui.starship.StarShipUiState
+import starship.virtualsoundnw.com.ui.starship.StarShipViewModel
 import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
 
 @Composable
 fun FittingsScreen(
     shipId: Int,
+    modifier: Modifier = Modifier,
+    viewModel: StarShipViewModel = hiltViewModel()
+) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    
+    when (val state = uiState.value) {
+        is StarShipUiState.Loading -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("Loading...")
+            }
+        }
+        is StarShipUiState.Error -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("Error: ${state.throwable.message}")
+            }
+        }
+        is StarShipUiState.Success -> {
+            val ship = state.data.find { it.uid == shipId }
+            FittingsContent(
+                ship = ship,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun FittingsContent(
+    ship: StarShip?,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -57,11 +99,20 @@ fun FittingsScreen(
                     fontWeight = FontWeight.Bold
                 )
                 
-                Text(
-                    text = "Ship ID: $shipId",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                if (ship != null) {
+                    val shipDesignation = if (ship.isCapitalShip) "Capital Ship" else "Ship"
+                    Text(
+                        text = "$shipDesignation: ${ship.name}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Text(
+                        text = "Ship not found",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
                 
                 Text(
                     text = "Coming Soon",
@@ -85,8 +136,15 @@ fun FittingsScreen(
 @Composable
 private fun FittingsScreenPreview() {
     MyApplicationTheme {
-        FittingsScreen(
-            shipId = 1
+        val sampleShip = StarShip(
+            "Constitution",
+            "Constitution class",
+            400,
+            TechLevel.G,
+            Configuration.STANDARD
+        )
+        FittingsContent(
+            ship = sampleShip
         )
     }
 }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.fittings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
+
+@Composable
+fun FittingsScreen(
+    shipId: Int,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Card(
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = "Fittings",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                
+                Text(
+                    text = "Ship ID: $shipId",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                
+                Text(
+                    text = "Coming Soon",
+                    style = MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                
+                Text(
+                    text = "This section will allow you to configure ship fittings, equipment, and other components.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FittingsScreenPreview() {
+    MyApplicationTheme {
+        FittingsScreen(
+            shipId = 1
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add conditional "Next: Fittings" button to Engines screen when required engines are present (≥1 power plant + ≥1 jump drive)
- Create new Fittings screen with proper ship designation display ("Ship: name" or "Capital Ship: Name" based on ship type)
- Add navigation route and integration between Engines and Fittings screens
- Replace hardcoded "Ship ID: 2" with dynamic ship data loading and display

## Test plan
- [x] Verify "Next: Fittings" button only appears when ship has required engines
- [x] Test navigation from Engines to Fittings screen works correctly 
- [x] Confirm Fittings screen displays proper ship designation based on ship type
- [x] Verify ship data loads correctly via StarShipViewModel
- [x] Test error handling for missing/invalid ships
- [x] Build passes without compilation errors

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/code)