### PR TITLE
Add Back: Engines and Next: Weapons navigation buttons to Fittings screen

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.rememberNavController
 import starship.virtualsoundnw.com.ui.starship.StarShipScreen
 import starship.virtualsoundnw.com.ui.engines.EnginesScreen
 import starship.virtualsoundnw.com.ui.fittings.FittingsScreen
+import starship.virtualsoundnw.com.ui.weapons.WeaponsScreen
 
 @Composable
 fun MainNavigation() {
@@ -55,6 +56,19 @@ fun MainNavigation() {
         composable("fittings/{shipId}") { backStackEntry ->
             val shipId = backStackEntry.arguments?.getString("shipId")?.toIntOrNull() ?: -1
             FittingsScreen(
+                shipId = shipId,
+                modifier = Modifier.padding(16.dp),
+                onNavigateToEngines = { shipId ->
+                    navController.navigate("engines/$shipId")
+                },
+                onNavigateToWeapons = { shipId ->
+                    navController.navigate("weapons/$shipId")
+                }
+            )
+        }
+        composable("weapons/{shipId}") { backStackEntry ->
+            val shipId = backStackEntry.arguments?.getString("shipId")?.toIntOrNull() ?: -1
+            WeaponsScreen(
                 shipId = shipId,
                 modifier = Modifier.padding(16.dp)
             )

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
@@ -22,10 +22,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
@@ -34,6 +37,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -64,7 +68,9 @@ import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
 fun FittingsScreen(
     shipId: Int,
     modifier: Modifier = Modifier,
-    viewModel: FittingsViewModel = hiltViewModel()
+    viewModel: FittingsViewModel = hiltViewModel(),
+    onNavigateToEngines: (Int) -> Unit = {},
+    onNavigateToWeapons: (Int) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -122,6 +128,14 @@ fun FittingsScreen(
                         FittingsSummaryPanel(
                             ship = ship,
                             uiState = uiState
+                        )
+                    }
+                    
+                    item {
+                        NavigationButtons(
+                            shipId = shipId,
+                            onNavigateToEngines = onNavigateToEngines,
+                            onNavigateToWeapons = onNavigateToWeapons
                         )
                     }
                 }
@@ -500,6 +514,33 @@ fun FittingsSummaryPanel(
     }
 }
 
+@Composable
+fun NavigationButtons(
+    shipId: Int,
+    onNavigateToEngines: (Int) -> Unit,
+    onNavigateToWeapons: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        OutlinedButton(
+            onClick = { onNavigateToEngines(shipId) }
+        ) {
+            Text("Back: Engines")
+        }
+        
+        Spacer(modifier = Modifier.width(16.dp))
+        
+        Button(
+            onClick = { onNavigateToWeapons(shipId) },
+            modifier = Modifier.weight(1f)
+        ) {
+            Text("Next: Weapons")
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun FittingsScreenPreview() {
@@ -548,6 +589,14 @@ private fun FittingsScreenPreview() {
                         ship = sampleShip,
                         fitting = sampleFitting
                     )
+                )
+            }
+            
+            item {
+                NavigationButtons(
+                    shipId = 1,
+                    onNavigateToEngines = { },
+                    onNavigateToWeapons = { }
                 )
             }
         }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsScreen.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.weapons
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
+
+@Composable
+fun WeaponsScreen(
+    shipId: Int,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Card(
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = "Weapons",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                
+                Text(
+                    text = "Coming Soon",
+                    style = MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                
+                Text(
+                    text = "This section will allow you to configure ship weapons, armaments, and defensive systems.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WeaponsScreenPreview() {
+    MyApplicationTheme {
+        WeaponsScreen(shipId = 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Add navigation buttons to Fittings screen for complete user flow
- Create "Back: Engines" button (outlined) to return to engines configuration
- Add "Next: Weapons" button (filled, primary) to advance to weapons section
- Create placeholder WeaponsScreen with "Coming Soon" message
- Update navigation routing to support complete flow: Ships → Engines → Fittings → Weapons

## Test plan
- [x] Verify "Back: Engines" button navigates to engines screen with correct ship ID
- [x] Test "Next: Weapons" button leads to weapons placeholder screen
- [x] Confirm complete navigation flow works end-to-end
- [x] Check button styling follows UI patterns (outlined vs filled)
- [x] Verify buttons are properly positioned and weighted
- [x] Build passes without compilation errors

## Navigation Flow Completion
This PR completes the fittings component implementation by adding the final navigation elements:

**Ships Screen** → Configure Engines → Configure Fittings → Configure Weapons

## Technical Implementation
- Created WeaponsScreen as placeholder with consistent styling
- Updated Navigation.kt with weapons route and proper parameter passing
- Enhanced FittingsScreen to accept navigation callbacks
- Added NavigationButtons composable with proper Material3 styling
- Maintained consistent button behavior with existing screens

This fulfills the final requirement for issue #11 (Add Fittings) by providing complete navigation transitions.

Closes #51
Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)