### PR TITLE
Restore engine delete and performance limiting functionality

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesScreen.kt
@@ -146,7 +146,7 @@ fun EnginesScreen(
                             onAddEngine = viewModel::addEngine,
                             onRemoveEngine = viewModel::removeEngine,
                             onUpdateEnginePerformance = viewModel::updateEnginePerformance,
-                            isPerformanceValid = { true },
+                            isPerformanceValid = viewModel::isManeuverPerformanceValid,
                             performanceRange = 0..12
                         )
                     }
@@ -277,7 +277,7 @@ fun EngineSection(
                         EngineControlCard(
                             engine = engine,
                             ship = ship,
-                            canRemove = isCapitalShip && engines.size > 1,
+                            canRemove = engines.size > 1,
                             onRemove = { onRemoveEngine(engine) },
                             onUpdatePerformance = { newPerformance ->
                                 onUpdateEnginePerformance(engine, newPerformance)

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
@@ -276,7 +276,22 @@ class EnginesViewModel @Inject constructor(
 
     fun isJumpPerformanceValid(performance: Int): Boolean {
         val ship = _uiState.value.ship ?: return false
-        return isJumpDrivePerformanceValidForTechLevel(performance, ship.techLevel)
+        val maxPowerPlantPerformance = getMaxPowerPlantPerformance()
+        
+        // Jump drives must not exceed max power plant performance AND must be valid for tech level
+        return performance <= maxPowerPlantPerformance && 
+               isJumpDrivePerformanceValidForTechLevel(performance, ship.techLevel)
+    }
+    
+    fun isManeuverPerformanceValid(performance: Int): Boolean {
+        val maxPowerPlantPerformance = getMaxPowerPlantPerformance()
+        
+        // Maneuver drives must not exceed max power plant performance
+        return performance <= maxPowerPlantPerformance
+    }
+    
+    private fun getMaxPowerPlantPerformance(): Int {
+        return _uiState.value.powerPlants.maxOfOrNull { it.performance } ?: 0
     }
 
     fun clearError() {


### PR DESCRIPTION
## Summary
- Fixed delete button logic to show when 2+ engines of same type exist (was showing only for capital ships)
- Added performance limiting for Maneuver drives based on Power Plant performance
- Enhanced Jump drive performance validation to include Power Plant constraints  
- Verified existing dynamic performance adjustment when Power Plants are deleted works correctly

## Test plan
- [x] Verify delete buttons appear when multiple engines of same type exist
- [x] Test maneuver drive performance is limited to max power plant performance
- [x] Test jump drive performance is limited to max power plant performance and tech level
- [x] Verify performance adjustment when power plants are deleted

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)