### PR TITLE
Add Ship Summary tabs to Fittings and Weapons screens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ sealed interface StarShipUiState {
 - Use Room database patterns for data persistence
 - Follow Compose UI patterns with StateFlow observation
 - Always run tests before finalizing work
+- Each new screen should include the Ship's Summary table, and when the new Screen allows adding items that use Tons and cost MCr, those get summed into the Summary correctly
 
 ### Copyright Management
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project uses a structured workflow combining GitHub Projects for backlog ma
 
 ### Backlog Management Loop
 
-Use the [Starship Project](https://github.com/users/DavidLDawes/projects/1) for all backlog management:
+Use the [Starship Project](https://github.com/users/DavidLDawes/projects/3/views/1) for all backlog management:
 
 1. **Create backlog entries** - Ensure entry requirements are met, include boilerplate Claude section that refers to the CLAUDE.md file for Claude's guidance & instructions including logging requirements, unit tests, etc.
 2. **Add new stories** as needed 
@@ -45,14 +45,15 @@ Use the [Starship Project](https://github.com/users/DavidLDawes/projects/1) for 
 For executing work on stories and bugs:
 
 1. **Operator invokes Claude** in a terminal window in the root of the github project
-2. **Claude gets instructions** from assigned stories/bugs using terminal commands like:
-   - `"Address github project issue Starship #8`
+2. **Claude gets instructions** from assigned stories/bugs using terminal commands from the operator like:
+   - `Address github project issue #8`
 3. **Claude does the work** following baseline architecture and conventions
 4. **Logs are copied** to the story/issue and Claude asks for approval
 5. **Human reviews and tests**, then either:
    - **a)** Adds requests for fixes, corrections, enhancements back to the story and re-invokes Claude, OR
    - **b)** Approves work and tells Claude to create a branch and PR for final review, approval and merging
-6. Operator cleanup: checkout main && git pull origin main
+6. Operator gives final merge approval in terminal:\
+  - `Approved, merge and switch back to main branch and pull the changes back`
 ### Architecture
 
 See [CLAUDE.md](CLAUDE.md) for detailed AI instructions and baseline architecture information.

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
@@ -28,11 +28,13 @@ import kotlinx.coroutines.launch
 import starship.virtualsoundnw.com.data.EnginesRepository
 import starship.virtualsoundnw.com.data.StarShipRepository
 import starship.virtualsoundnw.com.data.FittingsRepository
+import starship.virtualsoundnw.com.data.WeaponsRepository
 import starship.virtualsoundnw.com.data.local.database.Engine
 import starship.virtualsoundnw.com.data.local.database.EngineType
 import starship.virtualsoundnw.com.data.local.database.PowerPlantType
 import starship.virtualsoundnw.com.data.local.database.StarShip
 import starship.virtualsoundnw.com.data.local.database.Fitting
+import starship.virtualsoundnw.com.data.local.database.Weapon
 import starship.virtualsoundnw.com.data.local.database.calculateFuelRequirement
 import starship.virtualsoundnw.com.data.local.database.isJumpDrivePerformanceValidForTechLevel
 import javax.inject.Inject
@@ -47,6 +49,7 @@ data class EnginesUiState(
     val jumpDrives: List<Engine> = emptyList(),
     val maneuverDrives: List<Engine> = emptyList(),
     val fitting: Fitting? = null,
+    val weapons: List<Weapon> = emptyList(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null
 ) {

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -126,6 +127,13 @@ fun FittingsScreen(
                     
                     item {
                         FittingsSummaryPanel(
+                            ship = ship,
+                            uiState = uiState
+                        )
+                    }
+                    
+                    item {
+                        ShipSummaryPanel(
                             ship = ship,
                             uiState = uiState
                         )
@@ -597,6 +605,209 @@ private fun FittingsScreenPreview() {
                     shipId = 1,
                     onNavigateToEngines = { },
                     onNavigateToWeapons = { }
+                )
+            }
+        }
+    }
+}@Composable
+fun ShipSummaryPanel(
+    ship: StarShip,
+    uiState: FittingsUiState
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Ship Summary",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium
+            )
+            
+            val totalEngineTons = uiState.getTotalEngineTonnage()
+            val totalEngineCost = uiState.getTotalEngineCost()
+            val fuelTons = uiState.getFuelRequirement()
+            val fittingsTons = uiState.getTotalFittingsTonnage()
+            val fittingsCost = uiState.getTotalFittingsCost()
+            val weaponsTons = uiState.getTotalWeaponsTonnage()
+            val weaponsCost = uiState.getTotalWeaponsCost()
+            val remainingTons = uiState.getRemainingTonnage()
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Total Ship Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${ship.tons} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Engine Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", totalEngineTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Fuel Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", fuelTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Fittings Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", fittingsTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Weapons Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", weaponsTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            HorizontalDivider()
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Remaining Tonnage:",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "${String.format("%.1f", remainingTons)} tons",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = if (remainingTons >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                )
+            }
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Hull Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", ship.hullCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Engine Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", totalEngineCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Fittings Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.2f", fittingsCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Weapons Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", weaponsCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            HorizontalDivider()
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Total Cost:",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "${String.format("%.1f", ship.hullCost + totalEngineCost + fittingsCost + weaponsCost)} MCr",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.primary
                 )
             }
         }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.launch
 import starship.virtualsoundnw.com.data.FittingsRepository
 import starship.virtualsoundnw.com.data.StarShipRepository
 import starship.virtualsoundnw.com.data.EnginesRepository
+import starship.virtualsoundnw.com.data.WeaponsRepository
 import starship.virtualsoundnw.com.data.local.database.Fitting
 import starship.virtualsoundnw.com.data.local.database.StarShip
 import starship.virtualsoundnw.com.data.local.database.Engine
@@ -35,6 +36,9 @@ import starship.virtualsoundnw.com.data.local.database.EngineType
 import starship.virtualsoundnw.com.data.local.database.SensorType
 import starship.virtualsoundnw.com.data.local.database.ComputerModel
 import starship.virtualsoundnw.com.data.local.database.FittingsCalculation
+import starship.virtualsoundnw.com.data.local.database.Weapon
+import starship.virtualsoundnw.com.data.local.database.PowerPlantType
+import starship.virtualsoundnw.com.data.local.database.calculateFuelRequirement
 import javax.inject.Inject
 
 /**
@@ -44,6 +48,7 @@ data class FittingsUiState(
     val ship: StarShip? = null,
     val fitting: Fitting? = null,
     val engines: List<Engine> = emptyList(),
+    val weapons: List<Weapon> = emptyList(),
     val availableComputers: List<ComputerModel> = emptyList(),
     val maxJumpPerformance: Int = 0,
     val isLoading: Boolean = false,
@@ -101,13 +106,67 @@ data class FittingsUiState(
      * Get current computer model
      */
     fun getCurrentComputerModel(): ComputerModel = fitting?.computerModel ?: ComputerModel.CORE_1
+    
+    /**
+     * Calculate total engine tonnage
+     */
+    fun getTotalEngineTonnage(): Float {
+        return ship?.let { ship ->
+            engines.sumOf { engine -> engine.getTonnage(ship.tons).toDouble() }
+        }?.toFloat() ?: 0f
+    }
+    
+    /**
+     * Calculate total engine cost
+     */
+    fun getTotalEngineCost(): Float {
+        return ship?.let { ship ->
+            engines.sumOf { engine -> engine.getTotalCost(ship.tons, ship.techLevel).toDouble() }
+        }?.toFloat() ?: 0f
+    }
+    
+    /**
+     * Calculate fuel requirement
+     */
+    fun getFuelRequirement(): Float {
+        return ship?.let { ship ->
+            val maxJumpPerformance = engines.filter { it.type == EngineType.JUMP_DRIVE }
+                .maxOfOrNull { it.performance } ?: 0
+            val powerPlants = engines.filter { it.type == EngineType.POWER_PLANT }
+            val hasAntimatterPowerPlant = powerPlants.any { 
+                PowerPlantType.getBestAvailableForTechLevel(ship.techLevel) == PowerPlantType.ANTIMATTER
+            }
+            calculateFuelRequirement(maxJumpPerformance, ship.tons, hasAntimatterPowerPlant)
+        } ?: 0f
+    }
+    
+    /**
+     * Calculate total weapons cost
+     */
+    fun getTotalWeaponsCost(): Float = weapons.sumOf { it.getTotalCost().toDouble() }.toFloat()
+    
+    /**
+     * Calculate total weapons tonnage
+     */
+    fun getTotalWeaponsTonnage(): Float = weapons.sumOf { it.getTotalTonnage().toDouble() }.toFloat()
+    
+    /**
+     * Calculate remaining tonnage including all systems
+     */
+    fun getRemainingTonnage(): Float {
+        return ship?.let { ship ->
+            ship.tons - getTotalEngineTonnage() - getFuelRequirement() - 
+            getTotalFittingsTonnage() - getTotalWeaponsTonnage()
+        } ?: 0f
+    }
 }
 
 @HiltViewModel
 class FittingsViewModel @Inject constructor(
     private val fittingsRepository: FittingsRepository,
     private val starShipRepository: StarShipRepository,
-    private val enginesRepository: EnginesRepository
+    private val enginesRepository: EnginesRepository,
+    private val weaponsRepository: WeaponsRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FittingsUiState(isLoading = true))
@@ -120,12 +179,13 @@ class FittingsViewModel @Inject constructor(
         
         viewModelScope.launch {
             try {
-                // Combine ship data, engines, and fittings
+                // Combine ship data, engines, weapons, and fittings
                 combine(
                     starShipRepository.starShips,
                     enginesRepository.getEnginesForShip(shipId),
+                    weaponsRepository.getWeaponsForShip(shipId),
                     fittingsRepository.getFittingForShip(shipId)
-                ) { ships, engines, fitting ->
+                ) { ships, engines, weapons, fitting ->
                     val ship = ships.find { it.uid == shipId }
                     val maxJumpPerformance = engines
                         .filter { it.type == EngineType.JUMP_DRIVE }
@@ -143,6 +203,7 @@ class FittingsViewModel @Inject constructor(
                         ship = ship,
                         fitting = fitting,
                         engines = engines,
+                        weapons = weapons,
                         availableComputers = availableComputers,
                         maxJumpPerformance = maxJumpPerformance,
                         isLoading = false

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
@@ -65,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import starship.virtualsoundnw.com.data.local.database.TurretType
 import starship.virtualsoundnw.com.data.local.database.WeaponType
+import starship.virtualsoundnw.com.data.local.database.StarShip
 import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
 
 @Composable
@@ -134,6 +136,15 @@ fun WeaponsScreen(
                             }
                         }
                     )
+                }
+                
+                uiState.ship?.let { ship ->
+                    item {
+                        ShipSummaryPanel(
+                            ship = ship,
+                            uiState = uiState
+                        )
+                    }
                 }
             }
         }
@@ -448,6 +459,211 @@ fun getTurretDisplayName(turretType: TurretType): String {
         TurretType.POPUP_SINGLE -> "Single Pop-up Turret"
         TurretType.POPUP_DOUBLE -> "Double Pop-up Turret"
         TurretType.POPUP_TRIPLE -> "Triple Pop-up Turret"
+    }
+}
+
+@Composable
+fun ShipSummaryPanel(
+    ship: StarShip,
+    uiState: WeaponsUiState
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Ship Summary",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium
+            )
+            
+            val totalEngineTons = uiState.getTotalEngineTonnage()
+            val totalEngineCost = uiState.getTotalEngineCost()
+            val fuelTons = uiState.getFuelRequirement()
+            val fittingsTons = uiState.getTotalFittingsTonnage()
+            val fittingsCost = uiState.getTotalFittingsCost()
+            val weaponsTons = uiState.getTotalWeaponsTonnage()
+            val weaponsCost = uiState.getTotalWeaponsCost()
+            val remainingTons = uiState.getRemainingTonnage()
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Total Ship Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${ship.tons} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Engine Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", totalEngineTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Fuel Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", fuelTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Fittings Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", fittingsTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Weapons Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", weaponsTons)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            HorizontalDivider()
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Remaining Tonnage:",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "${String.format("%.1f", remainingTons)} tons",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = if (remainingTons >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                )
+            }
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Hull Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", ship.hullCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Engine Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", totalEngineCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Fittings Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.2f", fittingsCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Weapons Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", weaponsCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            HorizontalDivider()
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Total Cost:",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "${String.format("%.1f", ship.hullCost + totalEngineCost + fittingsCost + weaponsCost)} MCr",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsViewModel.kt
@@ -27,11 +27,18 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import starship.virtualsoundnw.com.data.WeaponsRepository
 import starship.virtualsoundnw.com.data.StarShipRepository
+import starship.virtualsoundnw.com.data.EnginesRepository
+import starship.virtualsoundnw.com.data.FittingsRepository
 import starship.virtualsoundnw.com.data.local.database.Weapon
 import starship.virtualsoundnw.com.data.local.database.StarShip
 import starship.virtualsoundnw.com.data.local.database.WeaponType
 import starship.virtualsoundnw.com.data.local.database.TurretType
 import starship.virtualsoundnw.com.data.local.database.calculateMaxHardpoints
+import starship.virtualsoundnw.com.data.local.database.Engine
+import starship.virtualsoundnw.com.data.local.database.Fitting
+import starship.virtualsoundnw.com.data.local.database.EngineType
+import starship.virtualsoundnw.com.data.local.database.PowerPlantType
+import starship.virtualsoundnw.com.data.local.database.calculateFuelRequirement
 import javax.inject.Inject
 
 /**
@@ -40,6 +47,8 @@ import javax.inject.Inject
 data class WeaponsUiState(
     val ship: StarShip? = null,
     val weapons: List<Weapon> = emptyList(),
+    val engines: List<Engine> = emptyList(),
+    val fitting: Fitting? = null,
     val isLoading: Boolean = false,
     val errorMessage: String? = null
 ) {
@@ -81,6 +90,63 @@ data class WeaponsUiState(
     }
     
     /**
+     * Calculate total engine tonnage
+     */
+    fun getTotalEngineTonnage(): Float {
+        return ship?.let { ship ->
+            engines.sumOf { engine -> engine.getTonnage(ship.tons).toDouble() }
+        }?.toFloat() ?: 0f
+    }
+    
+    /**
+     * Calculate total engine cost
+     */
+    fun getTotalEngineCost(): Float {
+        return ship?.let { ship ->
+            engines.sumOf { engine -> engine.getTotalCost(ship.tons, ship.techLevel).toDouble() }
+        }?.toFloat() ?: 0f
+    }
+    
+    /**
+     * Calculate fuel requirement
+     */
+    fun getFuelRequirement(): Float {
+        return ship?.let { ship ->
+            val maxJumpPerformance = engines.filter { it.type == EngineType.JUMP_DRIVE }
+                .maxOfOrNull { it.performance } ?: 0
+            val powerPlants = engines.filter { it.type == EngineType.POWER_PLANT }
+            val hasAntimatterPowerPlant = powerPlants.any { 
+                PowerPlantType.getBestAvailableForTechLevel(ship.techLevel) == PowerPlantType.ANTIMATTER
+            }
+            calculateFuelRequirement(maxJumpPerformance, ship.tons, hasAntimatterPowerPlant)
+        } ?: 0f
+    }
+    
+    /**
+     * Calculate total fittings tonnage
+     */
+    fun getTotalFittingsTonnage(): Float = ship?.let { ship ->
+        fitting?.getTotalTonnage(ship.tons) ?: (ship.tons * 0.005f) // Just bridge if no fitting
+    } ?: 0f
+    
+    /**
+     * Calculate total fittings cost
+     */
+    fun getTotalFittingsCost(): Float = ship?.let { ship ->
+        fitting?.getTotalCost(ship.tons) ?: (ship.tons * 0.005f * 0.1f) // Just bridge if no fitting
+    } ?: 0f
+    
+    /**
+     * Calculate remaining tonnage including all systems
+     */
+    fun getRemainingTonnage(): Float {
+        return ship?.let { ship ->
+            ship.tons - getTotalEngineTonnage() - getFuelRequirement() - 
+            getTotalFittingsTonnage() - getTotalWeaponsTonnage()
+        } ?: 0f
+    }
+    
+    /**
      * Group weapons by weapon type
      */
     fun getWeaponsByWeaponType(): Map<WeaponType, List<Weapon>> {
@@ -98,7 +164,9 @@ data class WeaponsUiState(
 @HiltViewModel
 class WeaponsViewModel @Inject constructor(
     private val weaponsRepository: WeaponsRepository,
-    private val starShipRepository: StarShipRepository
+    private val starShipRepository: StarShipRepository,
+    private val enginesRepository: EnginesRepository,
+    private val fittingsRepository: FittingsRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(WeaponsUiState(isLoading = true))
@@ -111,16 +179,20 @@ class WeaponsViewModel @Inject constructor(
         
         viewModelScope.launch {
             try {
-                // Combine ship data with weapons data
+                // Combine ship data with weapons, engines, and fittings data
                 combine(
                     starShipRepository.starShips,
-                    weaponsRepository.getWeaponsForShip(shipId)
-                ) { ships, weapons ->
+                    weaponsRepository.getWeaponsForShip(shipId),
+                    enginesRepository.getEnginesForShip(shipId),
+                    fittingsRepository.getFittingForShip(shipId)
+                ) { ships, weapons, engines, fitting ->
                     val ship = ships.find { it.uid == shipId }
                     
                     WeaponsUiState(
                         ship = ship,
                         weapons = weapons,
+                        engines = engines,
+                        fitting = fitting,
                         isLoading = false
                     )
                 }.collect { state ->


### PR DESCRIPTION
## Summary
- Added comprehensive Ship Summary panels to both Fittings and Weapons screens
- Enhanced ViewModels to include complete data access (engines, weapons, fittings) for accurate calculations
- Ship Summary shows all system tonnages and costs: engines, fuel, fittings, weapons
- Updated CLAUDE.md with architectural requirement for summary tables on new screens

## Test plan
- [x] Verify Ship Summary appears on Fittings screen with all tonnage/cost breakdowns
- [x] Verify Ship Summary appears on Weapons screen with all tonnage/cost breakdowns  
- [x] Test that all calculations are accurate and consistent across screens
- [x] Verify remaining tonnage calculation includes all systems
- [x] Test total cost calculation includes hull, engines, fittings, and weapons

Fixes #60

🤖 Generated with [Claude Code](https://claude.ai/code)