### PR TITLE
Add Back: Fittings and Next: Defenses buttons to Weapons page

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
@@ -29,6 +29,7 @@ import starship.virtualsoundnw.com.ui.starship.StarShipScreen
 import starship.virtualsoundnw.com.ui.engines.EnginesScreen
 import starship.virtualsoundnw.com.ui.fittings.FittingsScreen
 import starship.virtualsoundnw.com.ui.weapons.WeaponsScreen
+import starship.virtualsoundnw.com.ui.defenses.DefensesScreen
 
 @Composable
 fun MainNavigation() {
@@ -70,7 +71,23 @@ fun MainNavigation() {
             val shipId = backStackEntry.arguments?.getString("shipId")?.toIntOrNull() ?: -1
             WeaponsScreen(
                 shipId = shipId,
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier.padding(16.dp),
+                onNavigateToFittings = { shipId ->
+                    navController.navigate("fittings/$shipId")
+                },
+                onNavigateToDefenses = { shipId ->
+                    navController.navigate("defenses/$shipId")
+                }
+            )
+        }
+        composable("defenses/{shipId}") { backStackEntry ->
+            val shipId = backStackEntry.arguments?.getString("shipId")?.toIntOrNull() ?: -1
+            DefensesScreen(
+                shipId = shipId,
+                modifier = Modifier.padding(16.dp),
+                onNavigateToWeapons = { shipId ->
+                    navController.navigate("weapons/$shipId")
+                }
             )
         }
     }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/defenses/DefensesScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/defenses/DefensesScreen.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.defenses
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
+
+@Composable
+fun DefensesScreen(
+    shipId: Int,
+    modifier: Modifier = Modifier,
+    onNavigateToWeapons: (Int) -> Unit = {}
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            item {
+                DefensesComingSoonCard()
+            }
+        }
+    }
+}
+
+@Composable
+fun DefensesComingSoonCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Defenses",
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold
+            )
+            
+            Text(
+                text = "Coming soon...",
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            
+            Text(
+                text = "Ship defense systems configuration will be available in a future update.",
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DefensesScreenPreview() {
+    MyApplicationTheme {
+        DefensesScreen(shipId = 1)
+    }
+}

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
@@ -73,7 +74,9 @@ import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
 fun WeaponsScreen(
     shipId: Int,
     modifier: Modifier = Modifier,
-    viewModel: WeaponsViewModel = hiltViewModel()
+    viewModel: WeaponsViewModel = hiltViewModel(),
+    onNavigateToFittings: (Int) -> Unit = {},
+    onNavigateToDefenses: (Int) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -143,6 +146,14 @@ fun WeaponsScreen(
                         ShipSummaryPanel(
                             ship = ship,
                             uiState = uiState
+                        )
+                    }
+                    
+                    item {
+                        NavigationButtons(
+                            shipId = shipId,
+                            onNavigateToFittings = onNavigateToFittings,
+                            onNavigateToDefenses = onNavigateToDefenses
                         )
                     }
                 }
@@ -463,6 +474,33 @@ fun getTurretDisplayName(turretType: TurretType): String {
 }
 
 @Composable
+fun NavigationButtons(
+    shipId: Int,
+    onNavigateToFittings: (Int) -> Unit,
+    onNavigateToDefenses: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        OutlinedButton(
+            onClick = { onNavigateToFittings(shipId) }
+        ) {
+            Text("Back: Fittings")
+        }
+        
+        Spacer(modifier = Modifier.width(16.dp))
+        
+        Button(
+            onClick = { onNavigateToDefenses(shipId) },
+            modifier = Modifier.weight(1f)
+        ) {
+            Text("Next: Defenses")
+        }
+    }
+}
+
+@Composable
 fun ShipSummaryPanel(
     ship: StarShip,
     uiState: WeaponsUiState
@@ -682,6 +720,10 @@ fun getWeaponDisplayName(weaponType: WeaponType): String {
 @Composable
 private fun WeaponsScreenPreview() {
     MyApplicationTheme {
-        WeaponsScreen(shipId = 1)
+        WeaponsScreen(
+            shipId = 1,
+            onNavigateToFittings = { },
+            onNavigateToDefenses = { }
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Added navigation buttons to Weapons page: "Back: Fittings" and "Next: Defenses"
- Created DefensesScreen placeholder with "Coming soon..." message
- Updated Navigation.kt to include defenses route and complete navigation flow
- Complete ship configuration flow: Ship -> Engines -> Fittings -> Weapons -> Defenses

## Test plan
- [x] Verify "Back: Fittings" button navigates to Fittings screen
- [x] Verify "Next: Defenses" button navigates to new Defenses screen  
- [x] Test DefensesScreen shows "Coming soon..." message
- [x] Verify navigation flow works end-to-end
- [x] Test build compiles successfully

## Navigation Flow Completed
This completes the Add Weapons functionality (#12) by providing full navigation integration.

Fixes #64
Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)