### PR TITLE
Fix computer selection for ships with higher jump requirements

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/data/local/database/Fittings.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/local/database/Fittings.kt
@@ -80,14 +80,31 @@ enum class ComputerModel(
             maxJumpPerformance: Int,
             techLevel: TechLevel
         ): List<ComputerModel> {
-            return values().filter { model ->
-                // Check tech level requirement
-                techLevel >= model.requiredTechLevel &&
-                // Check size range (if model has size restrictions)
-                (model.sizeRangeMin == 0 || shipTonnage >= model.sizeRangeMin) &&
-                (model.sizeRangeMax == Int.MAX_VALUE || shipTonnage <= model.sizeRangeMax) &&
-                // Check jump performance requirement
-                model.jumpMinimum <= maxJumpPerformance
+            // Find minimum computer for tonnage
+            val minForTonnage = values()
+                .filter { techLevel >= it.requiredTechLevel }
+                .filter { shipTonnage >= it.sizeRangeMin && 
+                         (it.sizeRangeMax == Int.MAX_VALUE || shipTonnage <= it.sizeRangeMax) }
+                .minByOrNull { it.ordinal }
+            
+            // Find minimum computer for jump performance
+            val minForJump = values()
+                .filter { techLevel >= it.requiredTechLevel }
+                .filter { it.jumpMinimum >= maxJumpPerformance }
+                .minByOrNull { it.ordinal } // Use ordinal to get the earliest/lowest computer that can handle the jump
+            
+            // Use whichever requirement is higher (by ordinal - later in enum = higher)
+            val minimumRequired = listOfNotNull(minForTonnage, minForJump)
+                .maxByOrNull { it.ordinal }
+            
+            return if (minimumRequired != null) {
+                // Return minimum required computer and all higher computers
+                values().filter { model ->
+                    techLevel >= model.requiredTechLevel &&
+                    model.ordinal >= minimumRequired.ordinal
+                }
+            } else {
+                emptyList()
             }
         }
         

--- a/app/src/test/java/starship/virtualsoundnw/com/data/local/database/ComputerModelTest.kt
+++ b/app/src/test/java/starship/virtualsoundnw/com/data/local/database/ComputerModelTest.kt
@@ -34,20 +34,23 @@ class ComputerModelTest {
 
         val modelNames = availableModels.map { it.model }
         
-        // Core/1 (100-999 tons, Jump-1, Tech A) - should be available (jumpMinimum <= 3, tonnage fits)
-        assertTrue("Core/1 should be available for 800-ton ship", modelNames.contains("Core/1"))
+        // Core/1 (100-999 tons, Jump-1, Tech A) - should NOT be available for J-3 ship (can only handle J-1)
+        assertTrue("Core/1 should NOT be available for Jump-3 ship", !modelNames.contains("Core/1"))
         
-        // Core/10 (no size limit, Jump-7, Tech G) - should NOT be available (jumpMinimum > 3)
-        assertTrue("Core/10 should NOT be available for Jump-3 ship", !modelNames.contains("Core/10"))
+        // Core/5 (10001-50000 tons, Jump-3, Tech B) - should be available for Jump-3 at Tech G
+        assertTrue("Core/5 should be available for Jump-3 ship at Tech G", modelNames.contains("Core/5"))
+        
+        // Core/10 (no size limit, Jump-7, Tech G) - should be available (can handle J-3 and higher)
+        assertTrue("Core/10 should be available for Jump-3 ship at Tech G", modelNames.contains("Core/10"))
         
         // Verify we have at least some models returned (fix for issue #61)
         assertTrue("Should have available computer models", availableModels.isNotEmpty())
         
-        // Verify all returned models can handle the ship's jump performance
+        // All returned models should be valid for the tech level (this is enforced by the filtering logic)
         availableModels.forEach { model ->
             assertTrue(
-                "Model ${model.model} should support Jump-3 (jumpMinimum ${model.jumpMinimum} <= 3)",
-                model.jumpMinimum <= 3
+                "Model ${model.model} should be available at Tech G",
+                TechLevel.G >= model.requiredTechLevel
             )
         }
     }
@@ -62,15 +65,16 @@ class ComputerModelTest {
         )
 
         val modelNames = availableModels.map { it.model }
+        println("DEBUG: Available computers for 15000-ton J-4 ship: $modelNames")
         
-        // Core/5: jumpMinimum = 3, tonnage 10001-50000 - should be available
-        assertTrue("Core/5 should be available for Jump-4 ship", modelNames.contains("Core/5"))
+        // For J-4 ship, minimum required is Core/6 (jumpMinimum=4), so Core/5 should NOT be available
+        assertTrue("Core/5 should NOT be available for Jump-4 ship (insufficient jump capability)", !modelNames.contains("Core/5"))
         
-        // Core/6: jumpMinimum = 4, tonnage 50001-100000 - should NOT be available (tonnage too high)
-        assertTrue("Core/6 should NOT be available due to tonnage", !modelNames.contains("Core/6"))
+        // Core/6: jumpMinimum = 4, can handle Jump-4 - should be available
+        assertTrue("Core/6 should be available for Jump-4 ship", modelNames.contains("Core/6"))
         
-        // Core/10: jumpMinimum = 7 - should NOT be available (jumpMinimum > maxJumpPerformance)
-        assertTrue("Core/10 should NOT be available for Jump-4 ship", !modelNames.contains("Core/10"))
+        // Core/10: jumpMinimum = 7 - should be available (higher capability allowed)
+        assertTrue("Core/10 should be available for Jump-4 ship", modelNames.contains("Core/10"))
     }
 
     @Test
@@ -113,5 +117,41 @@ class ComputerModelTest {
         
         // Just check that we get some result for debugging
         assertTrue("Should have some result for debugging", availableModels.size >= 0)
+    }
+    
+    @Test
+    fun getAvailableModelsForShip_issue67_800tonJump2_showsCore3Plus() {
+        // Test case for Issue #67: 800-ton ship with Jump-2 should show Core/3+ computers
+        val availableModels = ComputerModel.getAvailableModelsForShip(
+            shipTonnage = 800,
+            maxJumpPerformance = 2,  // Jump-2 capability
+            techLevel = TechLevel.A
+        )
+        
+        val modelNames = availableModels.map { it.model }
+        println("DEBUG: Available computers for 800-ton J-2 ship: $modelNames")
+        
+        // Debug: Print all models that should match
+        ComputerModel.values().forEach { model ->
+            val techOk = TechLevel.A >= model.requiredTechLevel
+            val jumpOk = model.jumpMinimum <= 2
+            val sizeOk = model.sizeRangeMin == 0 || model.sizeRangeMax == Int.MAX_VALUE || 800 <= model.sizeRangeMax
+            println("${model.model}: tech=$techOk, jump=$jumpOk, size=$sizeOk -> ${techOk && jumpOk && sizeOk}")
+        }
+        
+        // Should NOT include Core/1 (only supports Jump-1)
+        assertTrue("Core/1 should NOT be available for Jump-2 ship", !modelNames.contains("Core/1"))
+        
+        // Should include Core/3 (Tech A, Jump-2)
+        assertTrue("Core/3 should be available for Jump-2 ship", modelNames.contains("Core/3"))
+        
+        // Should include Core/4 (Tech A, Jump-2) 
+        assertTrue("Core/4 should be available for Jump-2 ship", modelNames.contains("Core/4"))
+        
+        // Core/5 is Tech B, so should not be available at Tech A
+        assertTrue("Core/5 should NOT be available at Tech A", !modelNames.contains("Core/5"))
+        
+        // Should have at least Core/3 and Core/4 available
+        assertTrue("Should have at least 2 computer options for 800-ton J-2 ship at Tech A", availableModels.size >= 2)
     }
 }


### PR DESCRIPTION
## Summary

- Fixed computer selection logic to properly handle ships that require higher jump capabilities
- Implemented "higher of tonnage vs jump requirements" rule as clarified by user
- 800-ton J-2 ships now correctly show Core/3+ computers instead of only Core/1

## Changes

- **Updated `getAvailableModelsForShip()` logic** in `Fittings.kt`:
  - Find minimum computer for ship tonnage requirements
  - Find minimum computer for jump performance requirements  
  - Use whichever requirement is higher as the baseline
  - Return that minimum computer and all higher-rated computers

- **Updated test expectations** in `ComputerModelTest.kt`:
  - Aligned tests with new "minimum required + any higher" logic
  - Removed restrictions that conflicted with allowing higher-capability computers
  - Added specific test for Issue #67 scenario

## Test Results

- ✅ 800-ton J-2 ship at Tech A: Shows Core/3, Core/4 (previously only Core/1)
- ✅ All existing computer filtering tests pass with updated logic
- ✅ Tech level restrictions still properly enforced
- ✅ Both tonnage and jump requirements properly considered

## Issue Resolution

Closes #67 - 800-ton ships with Jump-2 capability can now select Core/3 and higher computers as expected.

🤖 Generated with [Claude Code](https://claude.ai/code)