### PR TITLE
Add Hull Codes for tonnage-based ship classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For executing work on stories and bugs:
 5. **Human reviews and tests**, then either:
    - **a)** Adds requests for fixes, corrections, enhancements back to the story and re-invokes Claude, OR
    - **b)** Approves work and tells Claude to create a branch and PR for final review, approval and merging
-6. Operator gives final merge approval in terminal:\
+6. Operator gives final merge approval in terminal:
   - `Approved, merge and switch back to main branch and pull the changes back`
 ### Architecture
 

--- a/app/src/main/java/starship/virtualsoundnw/com/data/local/database/StarShip.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/local/database/StarShip.kt
@@ -51,6 +51,8 @@ data class StarShip(
     
     val hullCost: Float get() = calculateHullCost(tons, configuration)
     
+    val hullCode: String get() = calculateHullCode(tons)
+    
     val shipDesignation: String get() = if (isCapitalShip) "Capital Ship" else "Ship"
 }
 
@@ -128,4 +130,63 @@ private fun calculateHullCost(tons: Int, configuration: Configuration): Float {
     }
     
     return baseCost * multiplier
+}
+
+/**
+ * Calculate Hull Code based on ship tonnage according to Issue #68 specifications
+ */
+private fun calculateHullCode(tons: Int): String {
+    return when (tons) {
+        // Single character codes for ships 100-2000 tons
+        100 -> "A"
+        in 191..200 -> "A"
+        in 201..300 -> "B"
+        in 301..400 -> "C"
+        in 401..500 -> "D"
+        in 501..600 -> "E"
+        in 601..700 -> "F"
+        in 701..800 -> "G"
+        in 801..900 -> "H"
+        in 901..1000 -> "J"
+        in 1001..1100 -> "K"
+        in 1101..1200 -> "L"
+        in 1201..1300 -> "M"
+        in 1301..1400 -> "N"
+        in 1401..1500 -> "P"
+        in 1501..1600 -> "Q"
+        in 1601..1700 -> "R"
+        in 1701..1800 -> "S"
+        in 1801..1900 -> "T"
+        in 1901..2000 -> "U"
+        
+        // Two character codes for capital ships 3000-1,000,000 tons
+        3000 -> "CA"
+        4000 -> "CB"
+        5000 -> "CC"
+        6000 -> "CD"
+        7500 -> "CE"
+        10000 -> "CF"
+        15000 -> "CG"
+        20000 -> "CH"
+        25000 -> "CJ"
+        30000 -> "CK"
+        40000 -> "CL"
+        50000 -> "CM"
+        60000 -> "CN"
+        75000 -> "CP"
+        100000 -> "CQ"
+        200000 -> "CR"
+        300000 -> "CS"
+        400000 -> "CT"
+        500000 -> "CU"
+        600000 -> "CV"
+        700000 -> "CW"
+        800000 -> "CX"
+        900000 -> "CY"
+        1000000 -> "CZ"
+        
+        // For tonnages not exactly matching the table, return "Unknown"
+        // This handles edge cases like 150 tons, 2500 tons, etc.
+        else -> "Unknown"
+    }
 }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/starship/StarShipScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/starship/StarShipScreen.kt
@@ -312,6 +312,7 @@ private fun ShipListItem(
                 style = MaterialTheme.typography.labelLarge,
                 modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
             )
+            Text(text = "Ship Code: ${ship.hullCode}")
             Text(text = "Hull Class: ${ship.hullClass}")
             Text(text = "Hull Cost: ${ship.hullCost} MCr")
             

--- a/app/src/test/java/starship/virtualsoundnw/com/data/local/database/StarShipTest.kt
+++ b/app/src/test/java/starship/virtualsoundnw/com/data/local/database/StarShipTest.kt
@@ -105,6 +105,94 @@ class StarShipTest {
         assertEquals("Buffered Planetoid", Configuration.BUFFERED_PLANETOID.displayName())
     }
 
+    @Test
+    fun hullCode_singleCharacterCodes_correctForSmallShips() {
+        // Test exact tonnages from Issue #68 specification
+        assertEquals("A", createShip(100).hullCode)
+        assertEquals("A", createShip(191).hullCode)
+        assertEquals("A", createShip(200).hullCode)
+        assertEquals("B", createShip(201).hullCode)
+        assertEquals("B", createShip(250).hullCode)
+        assertEquals("B", createShip(300).hullCode)
+        assertEquals("C", createShip(301).hullCode)
+        assertEquals("C", createShip(400).hullCode)
+        assertEquals("D", createShip(401).hullCode)
+        assertEquals("D", createShip(500).hullCode)
+        assertEquals("E", createShip(501).hullCode)
+        assertEquals("E", createShip(600).hullCode)
+        assertEquals("F", createShip(601).hullCode)
+        assertEquals("F", createShip(700).hullCode)
+        assertEquals("G", createShip(701).hullCode)
+        assertEquals("G", createShip(800).hullCode)
+        assertEquals("H", createShip(801).hullCode)
+        assertEquals("H", createShip(900).hullCode)
+        assertEquals("J", createShip(901).hullCode)
+        assertEquals("J", createShip(1000).hullCode)
+    }
+
+    @Test
+    fun hullCode_singleCharacterCodes_correctForLargerShips() {
+        // Test the higher ranges for single character codes
+        assertEquals("K", createShip(1001).hullCode)
+        assertEquals("K", createShip(1100).hullCode)
+        assertEquals("L", createShip(1101).hullCode)
+        assertEquals("L", createShip(1200).hullCode)
+        assertEquals("M", createShip(1201).hullCode)
+        assertEquals("M", createShip(1300).hullCode)
+        assertEquals("N", createShip(1301).hullCode)
+        assertEquals("N", createShip(1400).hullCode)
+        assertEquals("P", createShip(1401).hullCode)
+        assertEquals("P", createShip(1500).hullCode)
+        assertEquals("Q", createShip(1501).hullCode)
+        assertEquals("Q", createShip(1600).hullCode)
+        assertEquals("R", createShip(1601).hullCode)
+        assertEquals("R", createShip(1700).hullCode)
+        assertEquals("S", createShip(1701).hullCode)
+        assertEquals("S", createShip(1800).hullCode)
+        assertEquals("T", createShip(1801).hullCode)
+        assertEquals("T", createShip(1900).hullCode)
+        assertEquals("U", createShip(1901).hullCode)
+        assertEquals("U", createShip(2000).hullCode)
+    }
+
+    @Test
+    fun hullCode_twoCharacterCodes_correctForCapitalShips() {
+        // Test exact tonnages from Issue #68 specification
+        assertEquals("CA", createShip(3000).hullCode)
+        assertEquals("CB", createShip(4000).hullCode)
+        assertEquals("CC", createShip(5000).hullCode)
+        assertEquals("CD", createShip(6000).hullCode)
+        assertEquals("CE", createShip(7500).hullCode)
+        assertEquals("CF", createShip(10000).hullCode)
+        assertEquals("CG", createShip(15000).hullCode)
+        assertEquals("CH", createShip(20000).hullCode)
+        assertEquals("CJ", createShip(25000).hullCode)
+        assertEquals("CK", createShip(30000).hullCode)
+        assertEquals("CL", createShip(40000).hullCode)
+        assertEquals("CM", createShip(50000).hullCode)
+        assertEquals("CN", createShip(60000).hullCode)
+        assertEquals("CP", createShip(75000).hullCode)
+        assertEquals("CQ", createShip(100000).hullCode)
+        assertEquals("CR", createShip(200000).hullCode)
+        assertEquals("CS", createShip(300000).hullCode)
+        assertEquals("CT", createShip(400000).hullCode)
+        assertEquals("CU", createShip(500000).hullCode)
+        assertEquals("CV", createShip(600000).hullCode)
+        assertEquals("CW", createShip(700000).hullCode)
+        assertEquals("CX", createShip(800000).hullCode)
+        assertEquals("CY", createShip(900000).hullCode)
+        assertEquals("CZ", createShip(1000000).hullCode)
+    }
+
+    @Test
+    fun hullCode_unknownTonnages_returnsUnknown() {
+        // Test tonnages that don't match the exact specifications
+        assertEquals("Unknown", createShip(150).hullCode) // Between 100 and 191-200 range
+        assertEquals("Unknown", createShip(2500).hullCode) // Between 2000 and 3000
+        assertEquals("Unknown", createShip(3500).hullCode) // Between 3000 and 4000
+        assertEquals("Unknown", createShip(1500000).hullCode) // Above 1,000,000
+    }
+
     private fun createShip(tons: Int, configuration: Configuration = Configuration.STANDARD): StarShip {
         return StarShip(
             name = "Test Ship",


### PR DESCRIPTION
## Summary

Implemented Hull Code system for ships based on tonnage specifications from Issue #68. This provides a standardized classification system that will be used by future Defense and Screen systems for tonnage-dependent calculations.

## Changes

**StarShip Entity Updates:**
- Added `hullCode` calculated property to `StarShip` class
- Added `calculateHullCode()` function with complete tonnage specifications

**Hull Code System:**
- **Single character codes (A-U)** for ships 100-2000 tons:
  - 100 tons = "A", 191-200 = "A", 201-300 = "B", etc.
  - Complete coverage up to 1901-2000 = "U"
  
- **Two character codes (CA-CZ)** for capital ships 3000-1,000,000 tons:
  - 3000 = "CA", 4000 = "CB", 5000 = "CC", etc.
  - Complete coverage up to 1,000,000 = "CZ"

**UI Updates:**
- Ship Details panel now displays "Ship Code: X" in the Calculated Fields section
- Hull Code appears above existing Hull Class and Hull Cost information

**Test Coverage:**
- Added 4 comprehensive test suites covering all tonnage ranges
- Tests verify exact tonnage specifications from Issue #68
- Edge case testing for tonnages not in specification (returns "Unknown")

## Test Results

✅ **All existing tests pass** (no regressions)  
✅ **New Hull Code tests pass:**
- Single character codes for small ships (100-1000 tons)
- Single character codes for larger ships (1001-2000 tons)  
- Two character codes for capital ships (3000-1,000,000 tons)
- Unknown tonnages properly handled

## Future Integration

This Hull Code system is designed for future use by:
- Defense systems (tonnage-dependent armor/shield calculations)
- Screen systems (size-based defensive capabilities)
- Any other systems requiring ship size classification

## Example Output

- 200-ton ship: "Ship Code: A"
- 800-ton ship: "Ship Code: G" 
- 15,000-ton ship: "Ship Code: CG"

Closes #68

🤖 Generated with [Claude Code](https://claude.ai/code)