### PR TITLE
Add navigation buttons to Defense screen and create Vehicles placeholder (Issue #79)

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/Navigation.kt
@@ -30,6 +30,7 @@ import starship.virtualsoundnw.com.ui.engines.EnginesScreen
 import starship.virtualsoundnw.com.ui.fittings.FittingsScreen
 import starship.virtualsoundnw.com.ui.weapons.WeaponsScreen
 import starship.virtualsoundnw.com.ui.defenses.DefensesScreen
+import starship.virtualsoundnw.com.ui.vehicles.VehiclesScreen
 
 @Composable
 fun MainNavigation() {
@@ -87,6 +88,19 @@ fun MainNavigation() {
                 modifier = Modifier.padding(16.dp),
                 onNavigateToWeapons = { shipId ->
                     navController.navigate("weapons/$shipId")
+                },
+                onNavigateToVehicles = { shipId ->
+                    navController.navigate("vehicles/$shipId")
+                }
+            )
+        }
+        composable("vehicles/{shipId}") { backStackEntry ->
+            val shipId = backStackEntry.arguments?.getString("shipId")?.toIntOrNull() ?: -1
+            VehiclesScreen(
+                shipId = shipId,
+                modifier = Modifier.padding(16.dp),
+                onNavigateToDefenses = { shipId ->
+                    navController.navigate("defenses/$shipId")
                 }
             )
         }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/defenses/DefensesScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/defenses/DefensesScreen.kt
@@ -29,9 +29,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -56,7 +58,8 @@ fun DefensesScreen(
     shipId: Int,
     modifier: Modifier = Modifier,
     viewModel: DefensesViewModel = hiltViewModel(),
-    onNavigateToWeapons: (Int) -> Unit = {}
+    onNavigateToWeapons: (Int) -> Unit = {},
+    onNavigateToVehicles: (Int) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -124,6 +127,14 @@ fun DefensesScreen(
                             uiState = uiState
                         )
                     }
+                }
+                
+                item {
+                    DefensesNavigationButtons(
+                        shipId = shipId,
+                        onNavigateToWeapons = onNavigateToWeapons,
+                        onNavigateToVehicles = onNavigateToVehicles
+                    )
                 }
             }
         }
@@ -558,6 +569,33 @@ fun SummaryPanel(
                     fontWeight = FontWeight.Medium
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun DefensesNavigationButtons(
+    shipId: Int,
+    onNavigateToWeapons: (Int) -> Unit,
+    onNavigateToVehicles: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        OutlinedButton(
+            onClick = { onNavigateToWeapons(shipId) }
+        ) {
+            Text("Back: Weapons")
+        }
+        
+        Spacer(modifier = Modifier.width(16.dp))
+        
+        Button(
+            onClick = { onNavigateToVehicles(shipId) },
+            modifier = Modifier.weight(1f)
+        ) {
+            Text("Next: Vehicles")
         }
     }
 }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/vehicles/VehiclesScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/vehicles/VehiclesScreen.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.vehicles
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
+
+@Composable
+fun VehiclesScreen(
+    shipId: Int,
+    modifier: Modifier = Modifier,
+    onNavigateToDefenses: (Int) -> Unit = {}
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(
+                modifier = Modifier.padding(32.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text(
+                        text = "Vehicles Configuration",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center
+                    )
+                    
+                    Text(
+                        text = "Coming Soon",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                    
+                    Text(
+                        text = "Vehicle configuration and management features will be available in a future update.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun VehiclesScreenPreview() {
+    MyApplicationTheme {
+        VehiclesScreen(shipId = 1)
+    }
+}


### PR DESCRIPTION
## Summary
Completes Issue #79 by adding navigation buttons to the Defense screen and creates a placeholder Vehicles screen. This also completes Issue #13 (Add Defense) as the final navigation component.

## Changes Made

### 🔄 Defense Screen Navigation
- **"Back: Weapons" button** - returns to previous Weapons screen
- **"Next: Vehicles" button** - navigates to new Vehicles screen
- Added `DefensesNavigationButtons` composable following established patterns
- Enhanced `DefensesScreen` with `onNavigateToVehicles` callback

### 📱 New Vehicles Screen
- Created placeholder `VehiclesScreen.kt` with "Coming Soon" message
- Simple, consistent card layout explaining future vehicle configuration features
- Includes preview composable and proper Material3 theming
- Added to `ui.vehicles` package following project structure

### 🧭 Navigation System Updates
- Added `vehicles/{shipId}` route to `MainNavigation`
- Updated DefensesScreen navigation with proper callbacks
- Maintains navigation flow: **Weapons → Defenses → Vehicles**
- All routes properly handle shipId parameter passing

## Technical Implementation
- ✅ **Navigation buttons** follow established UI patterns from other screens
- ✅ **Route handling** matches existing navigation architecture
- ✅ **Screen structure** consistent with project conventions
- ✅ **Build successful** - all components compile correctly
- ✅ **Tests passing** - existing defense functionality unchanged

## Navigation Flow
1. **Weapons screen** → "Next: Defenses" → **Defense screen**
2. **Defense screen** → "Back: Weapons" / "Next: Vehicles"
3. **Vehicles screen** → "Back: Defenses" (for future implementation)

## Closes Issues
- Closes #79 (Add navigation buttons to Defense screen)
- Closes #13 (Add Defense - final navigation component)

The Defense system implementation is now complete with full navigation integration!

🤖 Generated with [Claude Code](https://claude.ai/code)