### PR TITLE
Fix ship summary display issues and add vehicles page summary (Issue #87)

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/data/ShipSummaryService.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/ShipSummaryService.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import starship.virtualsoundnw.com.data.local.database.StarShip
+import starship.virtualsoundnw.com.data.local.database.Engine
+import starship.virtualsoundnw.com.data.local.database.Weapon
+import starship.virtualsoundnw.com.data.local.database.Defense
+import starship.virtualsoundnw.com.data.local.database.Fitting
+import starship.virtualsoundnw.com.data.local.database.Cargo
+import starship.virtualsoundnw.com.data.local.database.EngineType
+import starship.virtualsoundnw.com.data.local.database.PowerPlantType
+import starship.virtualsoundnw.com.data.local.database.calculateFuelRequirement
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Centralized service for calculating comprehensive ship summaries
+ * across all systems without creating circular dependencies
+ */
+@Singleton
+class ShipSummaryService @Inject constructor(
+    private val starShipRepository: StarShipRepository,
+    private val enginesRepository: EnginesRepository,
+    private val weaponsRepository: WeaponsRepository,
+    private val defensesRepository: DefensesRepository,
+    private val fittingsRepository: FittingsRepository,
+    private val cargoRepository: CargoRepository
+) {
+    
+    /**
+     * Get comprehensive ship summary with all system data
+     */
+    fun getComprehensiveShipSummary(shipId: Int): Flow<ShipSummary?> {
+        return combine(
+            starShipRepository.starShips,
+            enginesRepository.getEnginesForShip(shipId),
+            weaponsRepository.getWeaponsForShip(shipId),
+            defensesRepository.getDefenseForShip(shipId),
+            fittingsRepository.getFittingForShip(shipId),
+            cargoRepository.getCargoForShip(shipId)
+        ) { flows ->
+            val ships = flows[0] as List<StarShip>
+            val engines = flows[1] as List<Engine>
+            val weapons = flows[2] as List<Weapon>
+            val defenses = flows[3] as Defense?
+            val fitting = flows[4] as Fitting?
+            val cargo = flows[5] as Cargo?
+            
+            ships.find { it.uid == shipId }?.let { ship ->
+                // Calculate engine tonnage including fuel
+                val baseEnginesTonnage = engines.sumOf { it.getTonnage(ship.tons).toDouble() }
+                val enginesCost = engines.sumOf { it.getTotalCost(ship.tons, ship.techLevel).toDouble() }
+                
+                // Calculate fuel requirement
+                val jumpPerformance = engines.filter { it.type == EngineType.JUMP_DRIVE }
+                    .maxOfOrNull { it.performance } ?: 0
+                val hasAntimatterPowerPlant = engines.filter { it.type == EngineType.POWER_PLANT }
+                    .any { engine -> 
+                        PowerPlantType.getBestAvailableForTechLevel(ship.techLevel) == 
+                        PowerPlantType.ANTIMATTER 
+                    }
+                val fuelTonnage = calculateFuelRequirement(
+                    jumpPerformance, ship.tons, hasAntimatterPowerPlant
+                ).toDouble()
+                val totalEnginesTonnage = baseEnginesTonnage + fuelTonnage
+                
+                val weaponsTonnage = weapons.sumOf { it.getTotalTonnage().toDouble() }
+                val weaponsCost = weapons.sumOf { it.getTotalCost().toDouble() }
+                
+                val defensesTonnage = defenses?.let { d ->
+                    (d.getArmorTonnage(ship.tons, ship.techLevel) + d.getScreenTonnage(ship.hullCode)).toDouble()
+                } ?: 0.0
+                val defensesCost = defenses?.let { d ->
+                    (d.getArmorCost(ship.tons, ship.configuration, ship.techLevel) + d.getScreenCost(ship.hullCode)).toDouble()
+                } ?: 0.0
+                
+                val fittingsTonnage = fitting?.getTotalTonnage(ship.tons)?.toDouble() ?: 0.0
+                val fittingsCost = fitting?.getTotalCost(ship.tons)?.toDouble() ?: 0.0
+                
+                val cargoTonnage = cargo?.getTotalTonnage() ?: 0
+                val cargoCost = cargo?.getTotalCargoCost()?.toDouble() ?: 0.0
+                
+                ShipSummary(
+                    ship = ship,
+                    enginesTonnage = totalEnginesTonnage,
+                    enginesCost = enginesCost,
+                    weaponsTonnage = weaponsTonnage,
+                    weaponsCost = weaponsCost,
+                    defensesTonnage = defensesTonnage,
+                    defensesCost = defensesCost,
+                    fittingsTonnage = fittingsTonnage,
+                    fittingsCost = fittingsCost,
+                    cargoTonnage = cargoTonnage,
+                    cargoCost = cargoCost
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoViewModel.kt
@@ -29,6 +29,7 @@ import starship.virtualsoundnw.com.data.StarShipRepository
 import starship.virtualsoundnw.com.data.local.database.StarShip
 import starship.virtualsoundnw.com.data.ShipSummary
 import starship.virtualsoundnw.com.data.CargoRepository
+import starship.virtualsoundnw.com.data.ShipSummaryService
 import javax.inject.Inject
 
 /**
@@ -48,7 +49,8 @@ data class CargoUiState(
 @HiltViewModel
 class CargoViewModel @Inject constructor(
     private val starShipRepository: StarShipRepository,
-    private val cargoRepository: CargoRepository
+    private val cargoRepository: CargoRepository,
+    private val shipSummaryService: ShipSummaryService
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CargoUiState())
@@ -62,7 +64,7 @@ class CargoViewModel @Inject constructor(
         
         viewModelScope.launch {
             try {
-                starShipRepository.getShipSummary(shipId).collect { shipSummary ->
+                shipSummaryService.getComprehensiveShipSummary(shipId).collect { shipSummary ->
                     if (shipSummary == null) {
                         _uiState.value = CargoUiState(
                             isLoading = false,

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/components/ShipSummaryPanel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/components/ShipSummaryPanel.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import starship.virtualsoundnw.com.data.local.database.StarShip
+
+/**
+ * Data class to hold ship summary information from all systems
+ */
+data class ShipSummaryData(
+    val ship: StarShip,
+    val enginesTonnage: Double = 0.0,
+    val enginesCost: Double = 0.0,
+    val weaponsTonnage: Double = 0.0,
+    val weaponsCost: Double = 0.0,
+    val defensesTonnage: Double = 0.0,
+    val defensesCost: Double = 0.0,
+    val fittingsTonnage: Double = 0.0,
+    val fittingsCost: Double = 0.0,
+    val cargoTonnage: Double = 0.0,
+    val cargoCost: Double = 0.0
+) {
+    val totalSystemsTonnage: Double get() = enginesTonnage + weaponsTonnage + defensesTonnage + fittingsTonnage + cargoTonnage
+    val totalSystemsCost: Double get() = enginesCost + weaponsCost + defensesCost + fittingsCost + cargoCost + ship.hullCost
+    val remainingTonnage: Double get() = ship.tons - totalSystemsTonnage
+}
+
+/**
+ * Comprehensive ship summary panel that shows all system details
+ * This replaces the individual screen-specific summary panels for consistency
+ */
+@Composable
+fun ComprehensiveShipSummaryPanel(
+    summaryData: ShipSummaryData,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Ship Summary",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium
+            )
+            
+            // Total ship tonnage
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Total Ship Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${summaryData.ship.tons} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            // Engines
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Engines:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", summaryData.enginesTonnage)} tons (${String.format("%.1f", summaryData.enginesCost)} MCr)",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            // Weapons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Weapons:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", summaryData.weaponsTonnage)} tons (${String.format("%.1f", summaryData.weaponsCost)} MCr)",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            // Defenses
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Defenses:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", summaryData.defensesTonnage)} tons (${String.format("%.1f", summaryData.defensesCost)} MCr)",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            // Fittings
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Fittings:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", summaryData.fittingsTonnage)} tons (${String.format("%.1f", summaryData.fittingsCost)} MCr)",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            // Cargo
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Cargo:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.0f", summaryData.cargoTonnage)} tons (${String.format("%.1f", summaryData.cargoCost)} MCr)",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            HorizontalDivider()
+            
+            // Totals
+            Text(
+                text = "Totals",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Remaining Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = "${String.format("%.1f", summaryData.remainingTonnage)} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = if (summaryData.remainingTonnage >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Total Ship Cost:",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "${String.format("%.2f", summaryData.totalSystemsCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesScreen.kt
@@ -492,6 +492,8 @@ fun SummaryPanel(
             val fuelTons = uiState.getFuelRequirement()
             val fittingsTons = uiState.getFittingsTonnage()
             val fittingsCost = uiState.getFittingsCost()
+            val weaponsTons = uiState.getTotalWeaponsTonnage()
+            val weaponsCost = uiState.getTotalWeaponsCost()
             val remainingTons = uiState.getRemainingTonnage()
             
             Row(
@@ -549,6 +551,21 @@ fun SummaryPanel(
                 )
                 Text(
                     text = "${String.format("%.1f", uiState.getFittingsTonnage())} tons",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Weapons Tonnage:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", weaponsTons)} tons",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -620,6 +637,21 @@ fun SummaryPanel(
                 )
             }
             
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Weapons Cost:",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${String.format("%.1f", weaponsCost)} MCr",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
             HorizontalDivider()
             
             Row(
@@ -632,7 +664,7 @@ fun SummaryPanel(
                     fontWeight = FontWeight.Medium
                 )
                 Text(
-                    text = "${String.format("%.1f", ship.hullCost + totalEngineCost + fittingsCost)} MCr",
+                    text = "${String.format("%.1f", ship.hullCost + totalEngineCost + fittingsCost + weaponsCost)} MCr",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.primary

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
@@ -119,6 +119,20 @@ data class EnginesUiState(
     }
     
     /**
+     * Calculate total weapons tonnage
+     */
+    fun getTotalWeaponsTonnage(): Float {
+        return weapons.sumOf { it.getTotalTonnage().toDouble() }.toFloat()
+    }
+    
+    /**
+     * Calculate total weapons cost
+     */
+    fun getTotalWeaponsCost(): Float {
+        return weapons.sumOf { it.getTotalCost().toDouble() }.toFloat()
+    }
+    
+    /**
      * Check if ship has required engines to proceed to fittings
      * Requires at least 1 power plant and 1 jump drive
      */
@@ -131,7 +145,8 @@ data class EnginesUiState(
 class EnginesViewModel @Inject constructor(
     private val enginesRepository: EnginesRepository,
     private val starShipRepository: StarShipRepository,
-    private val fittingsRepository: FittingsRepository
+    private val fittingsRepository: FittingsRepository,
+    private val weaponsRepository: WeaponsRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(EnginesUiState(isLoading = true))
@@ -144,12 +159,13 @@ class EnginesViewModel @Inject constructor(
         
         viewModelScope.launch {
             try {
-                // Combine ship data with engine data and fittings
+                // Combine ship data with engine data, fittings, and weapons
                 combine(
                     starShipRepository.starShips,
                     enginesRepository.getEnginesForShip(shipId),
-                    fittingsRepository.getFittingForShip(shipId)
-                ) { ships, engines, fitting ->
+                    fittingsRepository.getFittingForShip(shipId),
+                    weaponsRepository.getWeaponsForShip(shipId)
+                ) { ships, engines, fitting, weapons ->
                     val ship = ships.find { it.uid == shipId }
                     val powerPlants = engines.filter { it.type == EngineType.POWER_PLANT }
                     val jumpDrives = engines.filter { it.type == EngineType.JUMP_DRIVE }
@@ -162,6 +178,7 @@ class EnginesViewModel @Inject constructor(
                         jumpDrives = jumpDrives,
                         maneuverDrives = maneuverDrives,
                         fitting = fitting,
+                        weapons = weapons,
                         isLoading = false
                     )
                 }.collect { state ->

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/vehicles/VehiclesScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/vehicles/VehiclesScreen.kt
@@ -20,64 +20,147 @@ package starship.virtualsoundnw.com.ui.vehicles
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import starship.virtualsoundnw.com.data.local.database.StarShip
+import starship.virtualsoundnw.com.ui.components.ComprehensiveShipSummaryPanel
+import starship.virtualsoundnw.com.ui.components.ShipSummaryData
 import starship.virtualsoundnw.com.ui.theme.MyApplicationTheme
 
 @Composable
 fun VehiclesScreen(
     shipId: Int,
     modifier: Modifier = Modifier,
-    onNavigateToDefenses: (Int) -> Unit = {}
+    onNavigateToDefenses: (Int) -> Unit = {},
+    viewModel: VehiclesViewModel = hiltViewModel()
 ) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Card(
-                modifier = Modifier.padding(32.dp)
-            ) {
-                Column(
-                    modifier = Modifier.padding(32.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+    val uiState by viewModel.uiState.collectAsState()
+    
+    LaunchedEffect(shipId) {
+        viewModel.loadVehiclesForShip(shipId)
+    }
+    
+    Box(modifier = modifier.fillMaxSize()) {
+        if (uiState.isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center)
+            )
+        } else {
+            uiState.shipSummary?.let { shipSummary ->
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Text(
-                        text = "Vehicles Configuration",
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.Bold,
-                        textAlign = TextAlign.Center
-                    )
+                    item {
+                        VehiclesConfigurationHeader(ship = shipSummary.ship)
+                    }
                     
-                    Text(
-                        text = "Coming Soon",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center
-                    )
+                    item {
+                        ComprehensiveShipSummaryPanel(
+                            summaryData = ShipSummaryData(
+                                ship = shipSummary.ship,
+                                enginesTonnage = shipSummary.enginesTonnage,
+                                enginesCost = shipSummary.enginesCost,
+                                weaponsTonnage = shipSummary.weaponsTonnage,
+                                weaponsCost = shipSummary.weaponsCost,
+                                defensesTonnage = shipSummary.defensesTonnage,
+                                defensesCost = shipSummary.defensesCost,
+                                fittingsTonnage = shipSummary.fittingsTonnage,
+                                fittingsCost = shipSummary.fittingsCost,
+                                cargoTonnage = shipSummary.cargoTonnage.toDouble(),
+                                cargoCost = shipSummary.cargoCost
+                            )
+                        )
+                    }
                     
+                    item {
+                        VehiclesPlaceholderContent()
+                    }
+                }
+            } ?: run {
+                uiState.errorMessage?.let { error ->
                     Text(
-                        text = "Vehicle configuration and management features will be available in a future update.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center
+                        text = error,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(16.dp)
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun VehiclesConfigurationHeader(ship: StarShip) {
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Vehicles Configuration",
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Text(
+                text = "Ship: ${ship.name}",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = "${ship.tons} tons • TL ${ship.techLevel} • ${if (ship.isCapitalShip) "Capital Ship" else "Standard Ship"}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+fun VehiclesPlaceholderContent() {
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Coming Soon",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            
+            Text(
+                text = "Vehicle configuration and management features will be available in a future update.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
         }
     }
 }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/vehicles/VehiclesViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/vehicles/VehiclesViewModel.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.vehicles
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import starship.virtualsoundnw.com.data.ShipSummary
+import starship.virtualsoundnw.com.data.ShipSummaryService
+import javax.inject.Inject
+
+/**
+ * UI state for the Vehicles screen
+ */
+data class VehiclesUiState(
+    val shipSummary: ShipSummary? = null,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null
+)
+
+@HiltViewModel
+class VehiclesViewModel @Inject constructor(
+    private val shipSummaryService: ShipSummaryService
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(VehiclesUiState())
+    val uiState: StateFlow<VehiclesUiState> = _uiState.asStateFlow()
+
+    fun loadVehiclesForShip(shipId: Int) {
+        _uiState.value = VehiclesUiState(isLoading = true)
+        
+        viewModelScope.launch {
+            try {
+                shipSummaryService.getComprehensiveShipSummary(shipId).collect { shipSummary ->
+                    _uiState.value = VehiclesUiState(
+                        shipSummary = shipSummary,
+                        isLoading = false,
+                        errorMessage = if (shipSummary == null) "Ship with ID $shipId not found" else null
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = VehiclesUiState(
+                    isLoading = false,
+                    errorMessage = "Failed to load ship summary: ${e.message}"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed ship summary display on engines screen to show actual weapons tonnage instead of 0 tons
- Added comprehensive ship summary panel to vehicles page
- Created centralized ShipSummaryService for consistent ship summary calculations across all screens

## Changes Made
- **ShipSummaryService**: New centralized service for comprehensive ship summaries including fuel calculations
- **CargoViewModel**: Updated to use ShipSummaryService for accurate system tonnage display
- **EnginesViewModel**: Enhanced to include weapons data in ship summary calculations
- **EnginesScreen**: Fixed weapons display to show actual tonnage and cost values
- **VehiclesScreen**: Added ComprehensiveShipSummaryPanel with full system breakdown
- **VehiclesViewModel**: New ViewModel using ShipSummaryService for vehicles page

## Test Plan
- [x] Build project successfully
- [x] Verify engines screen shows correct weapons tonnage (1 ton for Triple Particle Beam Turret)
- [x] Verify vehicles page displays comprehensive ship summary
- [x] Verify cargo screen continues to work with new service
- [x] Test ship summary calculations include all systems (engines, weapons, defenses, fittings, cargo)

Fixes #87

🤖 Generated with [Claude Code](https://claude.ai/code)