### PR TITLE
Add Sections for Capital Ships (#102)

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/data/ShipSummaryService.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/ShipSummaryService.kt
@@ -98,8 +98,8 @@ class ShipSummaryService @Inject constructor(
                     (d.getArmorCost(ship.tons, ship.configuration, ship.techLevel) + d.getScreenCost(ship.hullCode)).toDouble()
                 } ?: 0.0
                 
-                val fittingsTonnage = fitting?.getTotalTonnage(ship.tons)?.toDouble() ?: 0.0
-                val fittingsCost = fitting?.getTotalCost(ship.tons)?.toDouble() ?: 0.0
+                val fittingsTonnage = fitting?.getTotalTonnage(ship.tons, ship.sections)?.toDouble() ?: 0.0
+                val fittingsCost = fitting?.getTotalCost(ship.tons, ship.sections)?.toDouble() ?: 0.0
                 
                 val cargoTonnage = cargo?.getTotalTonnage()?.toDouble() ?: 0.0
                 val cargoCost = cargo?.getTotalCargoCost()?.toDouble() ?: 0.0

--- a/app/src/main/java/starship/virtualsoundnw/com/data/local/database/Fittings.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/local/database/Fittings.kt
@@ -148,16 +148,16 @@ data class Fitting(
     /**
      * Calculate total fittings tonnage including bridge
      */
-    fun getTotalTonnage(shipTonnage: Int): Float {
-        val bridgeTonnage = calculateBridgeTonnage(shipTonnage)
+    fun getTotalTonnage(shipTonnage: Int, sections: Int = 1): Float {
+        val bridgeTonnage = calculateBridgeTonnage(shipTonnage, sections)
         return sensorType.tons + bridgeTonnage
     }
     
     /**
      * Calculate total fittings cost including bridge
      */
-    fun getTotalCost(shipTonnage: Int): Float {
-        val bridgeCost = calculateBridgeCost(shipTonnage)
+    fun getTotalCost(shipTonnage: Int, sections: Int = 1): Float {
+        val bridgeCost = calculateBridgeCost(shipTonnage, sections)
         return sensorType.cost + computerModel.cost + bridgeCost
     }
     
@@ -179,12 +179,12 @@ data class Fitting(
     /**
      * Get bridge tonnage based on ship size and capital ship status
      */
-    fun getBridgeTonnage(shipTonnage: Int): Float = calculateBridgeTonnage(shipTonnage)
+    fun getBridgeTonnage(shipTonnage: Int, sections: Int = 1): Float = calculateBridgeTonnage(shipTonnage, sections)
     
     /**
      * Get bridge cost (0.1 MCr per ton)
      */
-    fun getBridgeCost(shipTonnage: Int): Float = calculateBridgeCost(shipTonnage)
+    fun getBridgeCost(shipTonnage: Int, sections: Int = 1): Float = calculateBridgeCost(shipTonnage, sections)
 }
 
 @Dao
@@ -203,8 +203,8 @@ interface FittingDao {
 }
 
 // Helper calculation functions
-private fun calculateBridgeTonnage(shipTonnage: Int): Float {
-    return if (shipTonnage > 2000) {
+private fun calculateBridgeTonnage(shipTonnage: Int, sections: Int = 1): Float {
+    val baseBridgeTonnage = if (shipTonnage > 2000) {
         // Capital ships use 0.5% of ship tonnage
         shipTonnage * 0.005f
     } else {
@@ -216,10 +216,13 @@ private fun calculateBridgeTonnage(shipTonnage: Int): Float {
             else -> shipTonnage * 0.005f // Fallback to percentage (shouldn't happen)
         }
     }
+    
+    // Multiply by sections for capital ships (Issue #102)
+    return baseBridgeTonnage * sections
 }
 
-private fun calculateBridgeCost(shipTonnage: Int): Float {
-    val bridgeTonnage = calculateBridgeTonnage(shipTonnage)
+private fun calculateBridgeCost(shipTonnage: Int, sections: Int = 1): Float {
+    val bridgeTonnage = calculateBridgeTonnage(shipTonnage, sections)
     return bridgeTonnage * 0.1f // 0.1 MCr per ton
 }
 
@@ -235,8 +238,8 @@ data class FittingsCalculation(
     val sensorTonnage: Float get() = fitting?.getSensorTonnage() ?: 0f
     val sensorCost: Float get() = fitting?.getSensorCost() ?: 0f
     val computerCost: Float get() = fitting?.getComputerCost() ?: 0f
-    val bridgeTonnage: Float get() = calculateBridgeTonnage(ship.tons)
-    val bridgeCost: Float get() = calculateBridgeCost(ship.tons)
+    val bridgeTonnage: Float get() = calculateBridgeTonnage(ship.tons, ship.sections)
+    val bridgeCost: Float get() = calculateBridgeCost(ship.tons, ship.sections)
     val totalFittingsTonnage: Float get() = sensorTonnage + bridgeTonnage
     val totalFittingsCost: Float get() = sensorCost + computerCost + bridgeCost
 }

--- a/app/src/main/java/starship/virtualsoundnw/com/data/local/database/StarShip.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/local/database/StarShip.kt
@@ -53,6 +53,8 @@ data class StarShip(
     
     val hullCode: String get() = calculateHullCode(tons)
     
+    val sections: Int get() = calculateSections(hullCode)
+    
     val shipDesignation: String get() = if (isCapitalShip) "Capital Ship" else "Ship"
 }
 
@@ -188,5 +190,30 @@ private fun calculateHullCode(tons: Int): String {
         // For tonnages not exactly matching the table, return "Unknown"
         // This handles edge cases like 150 tons, 2500 tons, etc.
         else -> "Unknown"
+    }
+}
+
+/**
+ * Calculate number of sections for capital ships based on Hull Code according to Issue #102 specifications
+ */
+private fun calculateSections(hullCode: String): Int {
+    return when (hullCode) {
+        // CA to CE: 2 sections
+        "CA", "CB", "CC", "CD", "CE" -> 2
+        
+        // CF to CK: 3 sections
+        "CF", "CG", "CH", "CJ", "CK" -> 3
+        
+        // CL to CQ: 4 sections
+        "CL", "CM", "CN", "CP", "CQ" -> 4
+        
+        // CR to CV: 5 sections
+        "CR", "CS", "CT", "CU", "CV" -> 5
+        
+        // CW to CZ: 6 sections
+        "CW", "CX", "CY", "CZ" -> 6
+        
+        // Non-capital ships always have 1 section
+        else -> 1
     }
 }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/components/ShipSummaryPanel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/components/ShipSummaryPanel.kt
@@ -96,6 +96,24 @@ fun ComprehensiveShipSummaryPanel(
                 )
             }
             
+            // Sections (for capital ships)
+            if (summaryData.ship.sections > 1) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "Sections:",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        text = "${summaryData.ship.sections}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+            
             // Engines
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/engines/EnginesViewModel.kt
@@ -92,7 +92,7 @@ data class EnginesUiState(
      */
     fun getFittingsTonnage(): Float {
         return ship?.let { ship ->
-            fitting?.getTotalTonnage(ship.tons) ?: (ship.tons * 0.005f) // Just bridge if no fitting
+            fitting?.getTotalTonnage(ship.tons, ship.sections) ?: (ship.tons * 0.005f * ship.sections) // Just bridge if no fitting
         } ?: 0f
     }
     
@@ -101,7 +101,7 @@ data class EnginesUiState(
      */
     fun getFittingsCost(): Float {
         return ship?.let { ship ->
-            fitting?.getTotalCost(ship.tons) ?: (ship.tons * 0.005f * 0.1f) // Just bridge if no fitting
+            fitting?.getTotalCost(ship.tons, ship.sections) ?: (ship.tons * 0.005f * ship.sections * 0.1f) // Just bridge if no fitting
         } ?: 0f
     }
     

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsViewModel.kt
@@ -76,28 +76,28 @@ data class FittingsUiState(
      * Get bridge tonnage
      */
     fun getBridgeTonnage(): Float = ship?.let { s -> 
-        fitting?.getBridgeTonnage(s.tons) ?: (s.tons * 0.005f) 
+        fitting?.getBridgeTonnage(s.tons, s.sections) ?: (s.tons * 0.005f * s.sections) 
     } ?: 0f
     
     /**
      * Get bridge cost
      */
     fun getBridgeCost(): Float = ship?.let { s -> 
-        fitting?.getBridgeCost(s.tons) ?: (s.tons * 0.005f * 0.1f) 
+        fitting?.getBridgeCost(s.tons, s.sections) ?: (s.tons * 0.005f * s.sections * 0.1f) 
     } ?: 0f
     
     /**
      * Calculate total fittings tonnage
      */
     fun getTotalFittingsTonnage(): Float = ship?.let { s ->
-        fitting?.getTotalTonnage(s.tons) ?: (s.tons * 0.005f) // Just bridge if no fitting
+        fitting?.getTotalTonnage(s.tons, s.sections) ?: (s.tons * 0.005f * s.sections) // Just bridge if no fitting
     } ?: 0f
     
     /**
      * Calculate total fittings cost
      */
     fun getTotalFittingsCost(): Float = ship?.let { s ->
-        fitting?.getTotalCost(s.tons) ?: (s.tons * 0.005f * 0.1f) // Just bridge if no fitting
+        fitting?.getTotalCost(s.tons, s.sections) ?: (s.tons * 0.005f * s.sections * 0.1f) // Just bridge if no fitting
     } ?: 0f
     
     /**

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/weapons/WeaponsViewModel.kt
@@ -129,14 +129,14 @@ data class WeaponsUiState(
      * Calculate total fittings tonnage
      */
     fun getTotalFittingsTonnage(): Float = ship?.let { ship ->
-        fitting?.getTotalTonnage(ship.tons) ?: (ship.tons * 0.005f) // Just bridge if no fitting
+        fitting?.getTotalTonnage(ship.tons, ship.sections) ?: (ship.tons * 0.005f * ship.sections) // Just bridge if no fitting
     } ?: 0f
     
     /**
      * Calculate total fittings cost
      */
     fun getTotalFittingsCost(): Float = ship?.let { ship ->
-        fitting?.getTotalCost(ship.tons) ?: (ship.tons * 0.005f * 0.1f) // Just bridge if no fitting
+        fitting?.getTotalCost(ship.tons, ship.sections) ?: (ship.tons * 0.005f * ship.sections * 0.1f) // Just bridge if no fitting
     } ?: 0f
     
     /**


### PR DESCRIPTION
## Summary
Implements capital ship sections calculation based on Hull Code and updates bridge calculations accordingly.

## Changes Made
- **Sections Calculation**: Added `sections` property to StarShip entity based on Hull Code:
  - CA to CE: 2 sections
  - CF to CK: 3 sections  
  - CL to CQ: 4 sections
  - CR to CV: 5 sections
  - CW to CZ: 6 sections
  - Non-capital ships: 1 section

- **Ship Summary Display**: Updated ComprehensiveShipSummaryPanel to show "Sections: X" for capital ships

- **Bridge Calculations**: Updated bridge tonnage and cost calculations to multiply by sections count:
  - Each section has a Command Center
  - One Command Center serves as the Bridge
  - Updated all ViewModels and ShipSummaryService

## Test Plan
- [x] Build completes successfully
- [x] All unit tests pass
- [x] Sections display correctly for capital ships in ship summary
- [x] Bridge calculations properly multiply by sections count
- [x] Non-capital ships continue to work with 1 section

## Files Changed
- `StarShip.kt` - Added sections property and calculation logic
- `ShipSummaryPanel.kt` - Added sections display
- `Fittings.kt` - Updated bridge calculations with sections parameter
- `ShipSummaryService.kt` - Updated to pass sections parameter
- Multiple ViewModels - Updated bridge calculation calls

🤖 Generated with [Claude Code](https://claude.ai/code)