### PR TITLE
Implement round up formatting for tons and MCr to .1 units (Fixes #128)

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/components/DetailedShipTable.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/components/DetailedShipTable.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import starship.virtualsoundnw.com.data.DetailedShipTableData
 import starship.virtualsoundnw.com.data.ShipTableRow
+import starship.virtualsoundnw.com.ui.utils.RoundingUtils
 
 /**
  * Detailed ship table component showing all ship components with Category/Item/Tons/Cost/Crew
@@ -155,14 +156,14 @@ private fun ShipTableDataRow(row: ShipTableRow) {
             modifier = Modifier.weight(3f)
         )
         Text(
-            text = String.format("%.1f", row.tons),
+            text = RoundingUtils.formatTons(row.tons),
             style = MaterialTheme.typography.bodySmall,
             fontFamily = FontFamily.Monospace,
             textAlign = TextAlign.End,
             modifier = Modifier.weight(1.5f)
         )
         Text(
-            text = String.format("%.1f", row.costMCr),
+            text = RoundingUtils.formatMCr(row.costMCr),
             style = MaterialTheme.typography.bodySmall,
             fontFamily = FontFamily.Monospace,
             textAlign = TextAlign.End,
@@ -197,7 +198,7 @@ private fun ShipTableTotalRow(
             modifier = Modifier.weight(5f)
         )
         Text(
-            text = String.format("%.1f", tons),
+            text = RoundingUtils.formatTons(tons),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             fontFamily = FontFamily.Monospace,
@@ -205,7 +206,7 @@ private fun ShipTableTotalRow(
             modifier = Modifier.weight(1.5f)
         )
         Text(
-            text = String.format("%.1f", costMCr),
+            text = RoundingUtils.formatMCr(costMCr),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             fontFamily = FontFamily.Monospace,
@@ -237,7 +238,7 @@ private fun ShipTableRemainingTonsRow(remainingTons: Double) {
             modifier = Modifier.weight(5f)
         )
         Text(
-            text = String.format("%.1f", remainingTons),
+            text = RoundingUtils.formatTons(remainingTons),
             style = MaterialTheme.typography.bodyMedium,
             fontFamily = FontFamily.Monospace,
             fontWeight = if (remainingTons < 0) FontWeight.Bold else FontWeight.Normal,

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/components/ShipSummaryPanel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/components/ShipSummaryPanel.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import starship.virtualsoundnw.com.data.local.database.StarShip
+import starship.virtualsoundnw.com.ui.utils.RoundingUtils
 
 /**
  * Data class to hold ship summary information from all systems
@@ -128,7 +129,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.enginesTonnage)} tons (${String.format("%.1f", summaryData.enginesCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.enginesTonnage)} tons (${RoundingUtils.formatMCr(summaryData.enginesCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -144,7 +145,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.fuelTonnage)} tons",
+                    text = "${RoundingUtils.formatTons(summaryData.fuelTonnage)} tons",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -160,7 +161,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.weaponsTonnage)} tons (${String.format("%.1f", summaryData.weaponsCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.weaponsTonnage)} tons (${RoundingUtils.formatMCr(summaryData.weaponsCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -176,7 +177,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.defensesTonnage)} tons (${String.format("%.1f", summaryData.defensesCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.defensesTonnage)} tons (${RoundingUtils.formatMCr(summaryData.defensesCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -192,7 +193,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.fittingsTonnage)} tons (${String.format("%.1f", summaryData.fittingsCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.fittingsTonnage)} tons (${RoundingUtils.formatMCr(summaryData.fittingsCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -208,7 +209,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.0f", summaryData.cargoTonnage)} tons (${String.format("%.1f", summaryData.cargoCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.cargoTonnage)} tons (${RoundingUtils.formatMCr(summaryData.cargoCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -224,7 +225,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.vehiclesTonnage)} tons (${String.format("%.1f", summaryData.vehiclesCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.vehiclesTonnage)} tons (${RoundingUtils.formatMCr(summaryData.vehiclesCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -240,7 +241,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.dronesTonnage)} tons (${String.format("%.1f", summaryData.dronesCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.dronesTonnage)} tons (${RoundingUtils.formatMCr(summaryData.dronesCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -256,7 +257,7 @@ fun ComprehensiveShipSummaryPanel(
                     style = MaterialTheme.typography.bodyMedium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.berthsTonnage)} tons (${String.format("%.1f", summaryData.berthsCost)} MCr)",
+                    text = "${RoundingUtils.formatTons(summaryData.berthsTonnage)} tons (${RoundingUtils.formatMCr(summaryData.berthsCost)} MCr)",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium
                 )
@@ -282,7 +283,7 @@ fun ComprehensiveShipSummaryPanel(
                     fontWeight = FontWeight.Medium
                 )
                 Text(
-                    text = "${String.format("%.1f", summaryData.remainingTonnage)} tons",
+                    text = "${RoundingUtils.formatTons(summaryData.remainingTonnage)} tons",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                     color = if (summaryData.remainingTonnage >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
@@ -299,7 +300,7 @@ fun ComprehensiveShipSummaryPanel(
                     fontWeight = FontWeight.Bold
                 )
                 Text(
-                    text = "${String.format("%.2f", summaryData.totalSystemsCost)} MCr",
+                    text = "${RoundingUtils.formatMCr(summaryData.totalSystemsCost)} MCr",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold
                 )

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/export/ShipCsvExportService.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/export/ShipCsvExportService.kt
@@ -23,6 +23,7 @@ import android.content.ClipboardManager
 import androidx.core.content.ContextCompat.getSystemService
 import starship.virtualsoundnw.com.data.DetailedShipTableData
 import starship.virtualsoundnw.com.data.ShipTableRow
+import starship.virtualsoundnw.com.ui.utils.RoundingUtils
 import java.io.File
 import java.io.FileWriter
 import java.io.IOException
@@ -56,7 +57,7 @@ class ShipCsvExportService @Inject constructor() {
         for (row in tableData.rows) {
             val category = if (row.isFirstInCategory) row.category else ""
             csvBuilder.appendLine(
-                "${escapeForCsv(category)},${escapeForCsv(row.item)},${row.tons},${row.costMCr},${row.crew}"
+                "${escapeForCsv(category)},${escapeForCsv(row.item)},${RoundingUtils.roundUpTons(row.tons)},${RoundingUtils.roundUpMCr(row.costMCr)},${row.crew}"
             )
         }
         
@@ -64,10 +65,10 @@ class ShipCsvExportService @Inject constructor() {
         csvBuilder.appendLine()
         
         // Totals row
-        csvBuilder.appendLine("TOTALS,,${tableData.totalTons},${tableData.totalCostMCr},${tableData.totalCrew}")
+        csvBuilder.appendLine("TOTALS,,${RoundingUtils.roundUpTons(tableData.totalTons)},${RoundingUtils.roundUpMCr(tableData.totalCostMCr)},${tableData.totalCrew}")
         
         // Remaining tons
-        csvBuilder.appendLine("Remaining Tons,,${tableData.remainingTons},,")
+        csvBuilder.appendLine("Remaining Tons,,${RoundingUtils.roundUpTons(tableData.remainingTons)},,")
         
         return csvBuilder.toString()
     }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/print/ShipPrintDocumentAdapter.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/print/ShipPrintDocumentAdapter.kt
@@ -32,6 +32,7 @@ import android.graphics.Typeface
 import android.graphics.pdf.PdfDocument
 import starship.virtualsoundnw.com.data.DetailedShipTableData
 import starship.virtualsoundnw.com.data.ShipTableRow
+import starship.virtualsoundnw.com.ui.utils.RoundingUtils
 import java.io.FileOutputStream
 import java.io.IOException
 
@@ -200,8 +201,8 @@ class ShipPrintDocumentAdapter(
             }
             
             val category = if (row.isFirstInCategory) row.category else ""
-            val rowText = String.format("%-20s %-25s %10.1f %12.3f %8d", 
-                category, row.item, row.tons, row.costMCr, row.crew)
+            val rowText = String.format("%-20s %-25s %10.1f %12.1f %8d", 
+                category, row.item, RoundingUtils.roundUpTons(row.tons), RoundingUtils.roundUpMCr(row.costMCr), row.crew)
             canvas.drawText(rowText, margin, yPos, bodyPaint)
             yPos += 18f
         }
@@ -211,13 +212,13 @@ class ShipPrintDocumentAdapter(
         canvas.drawLine(margin, yPos, margin + contentWidth, yPos, linePaint)
         yPos += 20f
         
-        val totalsText = String.format("%-20s %-25s %10.1f %12.3f %8d", 
-            "", "TOTALS", tableData.totalTons, tableData.totalCostMCr, tableData.totalCrew)
+        val totalsText = String.format("%-20s %-25s %10.1f %12.1f %8d", 
+            "", "TOTALS", RoundingUtils.roundUpTons(tableData.totalTons), RoundingUtils.roundUpMCr(tableData.totalCostMCr), tableData.totalCrew)
         canvas.drawText(totalsText, margin, yPos, headerPaint)
         yPos += 25f
         
         // Draw remaining tons
-        val remainingText = String.format("Remaining Tons: %.1f", tableData.remainingTons)
+        val remainingText = String.format("Remaining Tons: %.1f", RoundingUtils.roundUpTons(tableData.remainingTons))
         canvas.drawText(remainingText, margin, yPos, bodyPaint)
     }
 

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/utils/RoundingUtils.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/utils/RoundingUtils.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.utils
+
+import kotlin.math.ceil
+
+/**
+ * Utility functions for rounding ship design values
+ */
+object RoundingUtils {
+    
+    /**
+     * Round up tons to nearest .1 units
+     * Examples: 12.05 -> 12.1, 12.0 -> 12.0, 12.01 -> 12.1
+     */
+    fun roundUpTons(tons: Double): Double {
+        return ceil(tons * 10) / 10.0
+    }
+    
+    /**
+     * Round up MCr (MegaCredits) to nearest .1 units
+     * Examples: 5.05 -> 5.1, 5.0 -> 5.0, 5.01 -> 5.1
+     */
+    fun roundUpMCr(costMCr: Double): Double {
+        return ceil(costMCr * 10) / 10.0
+    }
+    
+    /**
+     * Format tons with rounding up to .1 units for display
+     */
+    fun formatTons(tons: Double): String {
+        return String.format("%.1f", roundUpTons(tons))
+    }
+    
+    /**
+     * Format MCr with rounding up to .1 units for display
+     */
+    fun formatMCr(costMCr: Double): String {
+        return String.format("%.1f", roundUpMCr(costMCr))
+    }
+}

--- a/app/src/test/java/starship/virtualsoundnw/com/ui/utils/RoundingUtilsTest.kt
+++ b/app/src/test/java/starship/virtualsoundnw/com/ui/utils/RoundingUtilsTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 David L. Dawes
+ * Notice: As this license may require, be aware this file is new and had been added by David L. Dawes since cloning the original archive from github.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package starship.virtualsoundnw.com.ui.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [RoundingUtils]
+ */
+class RoundingUtilsTest {
+
+    @Test
+    fun roundUpTons_exactDecimal_remainsUnchanged() {
+        assertEquals(12.0, RoundingUtils.roundUpTons(12.0), 0.001)
+        assertEquals(5.1, RoundingUtils.roundUpTons(5.1), 0.001)
+        assertEquals(0.2, RoundingUtils.roundUpTons(0.2), 0.001)
+    }
+
+    @Test
+    fun roundUpTons_needsRoundingUp_roundsToNearestTenth() {
+        assertEquals(12.1, RoundingUtils.roundUpTons(12.05), 0.001)
+        assertEquals(12.1, RoundingUtils.roundUpTons(12.01), 0.001)
+        assertEquals(5.2, RoundingUtils.roundUpTons(5.15), 0.001)
+        assertEquals(0.1, RoundingUtils.roundUpTons(0.05), 0.001)
+        assertEquals(0.1, RoundingUtils.roundUpTons(0.001), 0.001)
+    }
+
+    @Test
+    fun roundUpTons_zeroValue_remainsZero() {
+        assertEquals(0.0, RoundingUtils.roundUpTons(0.0), 0.001)
+    }
+
+    @Test
+    fun roundUpTons_negativeValues_roundsUpTowardsZero() {
+        assertEquals(-12.0, RoundingUtils.roundUpTons(-12.0), 0.001)
+        assertEquals(-12.0, RoundingUtils.roundUpTons(-12.05), 0.001)
+        assertEquals(-12.0, RoundingUtils.roundUpTons(-12.01), 0.001)
+    }
+
+    @Test
+    fun roundUpMCr_exactDecimal_remainsUnchanged() {
+        assertEquals(25.0, RoundingUtils.roundUpMCr(25.0), 0.001)
+        assertEquals(10.5, RoundingUtils.roundUpMCr(10.5), 0.001)
+        assertEquals(0.3, RoundingUtils.roundUpMCr(0.3), 0.001)
+    }
+
+    @Test
+    fun roundUpMCr_needsRoundingUp_roundsToNearestTenth() {
+        assertEquals(25.1, RoundingUtils.roundUpMCr(25.05), 0.001)
+        assertEquals(25.1, RoundingUtils.roundUpMCr(25.01), 0.001)
+        assertEquals(10.6, RoundingUtils.roundUpMCr(10.55), 0.001)
+        assertEquals(0.1, RoundingUtils.roundUpMCr(0.05), 0.001)
+        assertEquals(0.1, RoundingUtils.roundUpMCr(0.001), 0.001)
+    }
+
+    @Test
+    fun roundUpMCr_zeroValue_remainsZero() {
+        assertEquals(0.0, RoundingUtils.roundUpMCr(0.0), 0.001)
+    }
+
+    @Test
+    fun formatTons_returnsProperStringFormat() {
+        assertEquals("12.1", RoundingUtils.formatTons(12.05))
+        assertEquals("12.0", RoundingUtils.formatTons(12.0))
+        assertEquals("0.1", RoundingUtils.formatTons(0.05))
+        assertEquals("5.2", RoundingUtils.formatTons(5.15))
+    }
+
+    @Test
+    fun formatMCr_returnsProperStringFormat() {
+        assertEquals("25.1", RoundingUtils.formatMCr(25.05))
+        assertEquals("25.0", RoundingUtils.formatMCr(25.0))
+        assertEquals("0.1", RoundingUtils.formatMCr(0.05))
+        assertEquals("10.6", RoundingUtils.formatMCr(10.55))
+    }
+
+    @Test
+    fun formatTons_handlesLargeValues() {
+        assertEquals("1000.1", RoundingUtils.formatTons(1000.05))
+        assertEquals("9999.9", RoundingUtils.formatTons(9999.85))
+    }
+
+    @Test
+    fun formatMCr_handlesLargeValues() {
+        assertEquals("500.1", RoundingUtils.formatMCr(500.05))
+        assertEquals("1234.6", RoundingUtils.formatMCr(1234.55))
+    }
+}


### PR DESCRIPTION
## Summary
- Implement consistent rounding UP of tons and MCr values to nearest .1 units
- Update Ship Summary and Ship Review screens with proper round-up formatting
- Add centralized rounding utilities for consistent behavior across all displays
- Ensure export outputs (CSV and Print) maintain same rounding consistency

## Changes Made

### Rounding Utilities
- **RoundingUtils** - Object with centralized rounding functions
- **roundUpTons()** - Rounds tonnage up to nearest .1 units using `ceil(tons * 10) / 10.0`
- **roundUpMCr()** - Rounds MegaCredits up to nearest .1 units using `ceil(cost * 10) / 10.0`
- **formatTons()** - Formats tons with up-rounding for display
- **formatMCr()** - Formats MCr with up-rounding for display

### Ship Summary Panel Updates
Updated all tonnage and cost displays to use rounding utilities:
- **Engines**: Tonnage and cost rounded up to .1 units
- **Fuel**: Tonnage rounded up to .1 units
- **Weapons**: Tonnage and cost rounded up to .1 units
- **Defenses**: Tonnage and cost rounded up to .1 units
- **Fittings**: Tonnage and cost rounded up to .1 units
- **Cargo**: Tonnage and cost rounded up to .1 units
- **Vehicles**: Tonnage and cost rounded up to .1 units
- **Drones**: Tonnage and cost rounded up to .1 units
- **Berths**: Tonnage and cost rounded up to .1 units
- **Total Ship Cost**: Rounded up to .1 units
- **Remaining Tonnage**: Rounded up to .1 units

### Ship Review Table Updates
Updated DetailedShipTable component:
- **Component Rows**: Individual item tonnage and cost rounded up to .1 units
- **Totals Row**: Summary totals rounded up to .1 units
- **Remaining Tons**: Rounded up to .1 units with proper error styling

### Export Output Consistency
- **CSV Export**: All tonnage and cost values use up-rounding
- **Print Output**: All tonnage and cost values in PDF use up-rounding
- **Consistent Formatting**: Same rounding behavior across all export formats

### Testing
- Added comprehensive unit tests for RoundingUtils (11 new tests)
- Tests for exact decimals, rounding up behavior, zero values, and negative values
- Tests for format string output and large value handling
- All existing tests continue to pass (131 total tests)

## Rounding Examples
- **12.05 tons → 12.1 tons** (rounds up from .05)
- **12.0 tons → 12.0 tons** (exact values unchanged)
- **12.01 tons → 12.1 tons** (always rounds up, never down)
- **25.05 MCr → 25.1 MCr** (rounds up from .05)
- **0.05 tons → 0.1 tons** (small values round up properly)

## Test plan
- [x] Build completes successfully with no errors
- [x] All 131 unit tests pass (including 11 new rounding tests)
- [x] Ship Summary Panel displays rounded values for all systems
- [x] Ship Review Table displays rounded values for components and totals
- [x] CSV export uses rounded values consistently
- [x] Print output uses rounded values consistently
- [x] Rounding always goes UP to nearest .1 units (never down)
- [x] Zero and exact decimal values remain unchanged

## Acceptance Criteria Met
- [x] Tons rounded up to nearest .1 units in Ship Summary screens ✓
- [x] MCr rounded up to nearest .1 units in Ship Summary screens ✓
- [x] Tons rounded up to nearest .1 units in Ship Review screens ✓
- [x] MCr rounded up to nearest .1 units in Ship Review screens ✓

🤖 Generated with [Claude Code](https://claude.ai/code)