### PR TITLE
Fix Pilot/Navigator display formatting for small ships (Fixes #76)

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/data/local/database/Crew.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/data/local/database/Crew.kt
@@ -67,7 +67,11 @@ data class CrewMember(
         CrewType.FREIGHT -> "Freight"
     }
     
-    val description: String get() = "$quantity $displayName${if (quantity > 1) "s" else ""} - $assignment"
+    val description: String get() = when {
+        // Handle combined roles like "Pilot/Navigator for X ton vessel"
+        assignment.startsWith("Pilot/Navigator") -> "$quantity Pilot/Navigator"
+        else -> "$quantity $displayName${if (quantity > 1) "s" else ""} - $assignment"
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes the crew display issue reported in the final comment on Issue #76
- Changes "1 pilot - Pilot/Navigator for X ton vessel" to display as "1 Pilot/Navigator" 
- Adds special case handling in CrewMember.description for combined Pilot/Navigator roles
- Maintains correct formatting for all other crew member types

## Test plan
- [ ] Verify small ships (≤200 tons) now show "1 Pilot/Navigator" in Fittings crew panel
- [ ] Verify other crew types still display correctly with their assignments
- [ ] Run unit tests to ensure no regressions
- [ ] Test with different ship sizes to ensure only small ships are affected

🤖 Generated with [Claude Code](https://claude.ai/code)