### PR TITLE
Remove inaccurate bridge calculation text (Fixes #132)

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/fittings/FittingsScreen.kt
@@ -427,12 +427,6 @@ fun BridgeSection(
                 fontWeight = FontWeight.Medium
             )
             
-            Text(
-                text = "Automatically calculated as 0.5% of ship tonnage",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween


### PR DESCRIPTION
## Summary
- Removes the misleading text "Automatically calculated as 0.5% of ship tonnage" from the Bridge section on the Fittings screen
- This text was inaccurate for Capital ships (which use 0.5% per section with at least 2 sections)
- This text did not apply to non-Capital ships at all
- The bridge tonnage and cost calculations remain correct and are still displayed

## Test plan
- [ ] Verify Bridge section on Fittings screen no longer shows the inaccurate calculation text
- [ ] Confirm bridge tonnage and cost are still displayed correctly
- [ ] Test with both capital ships and non-capital ships
- [ ] Run unit tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)