### PR TITLE
Fix cargo sliders to allow reducing allocations when over-tonnage (Fixes #133)

### DIFF
--- a/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoScreen.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoScreen.kt
@@ -170,7 +170,7 @@ fun CargoConfigurationCard(
             
             if (uiState.isCargoEditingDisabled) {
                 Text(
-                    text = "Cargo editing disabled: No remaining ship tonnage available",
+                    text = "Ship over-tonnage: Only existing cargo allocations can be reduced",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.error,
                     fontWeight = FontWeight.Medium
@@ -182,7 +182,7 @@ fun CargoConfigurationCard(
                 cargoType = CargoType.CARGO,
                 currentTons = uiState.cargoTons,
                 maxTons = uiState.getAvailableTonnageFor(CargoType.CARGO),
-                enabled = !uiState.isCargoEditingDisabled,
+                enabled = uiState.canEditCargoType(CargoType.CARGO),
                 onValueChange = onCargoUpdate
             )
             
@@ -192,7 +192,7 @@ fun CargoConfigurationCard(
                 currentTons = uiState.sparesTons,
                 maxTons = uiState.getAvailableTonnageFor(CargoType.SPARES),
                 stepSize = uiState.sparesStepSize,
-                enabled = !uiState.isCargoEditingDisabled,
+                enabled = uiState.canEditCargoType(CargoType.SPARES),
                 onValueChange = onCargoUpdate,
                 extraInfo = "Service every ${uiState.serviceIntervalMonths} months"
             )
@@ -202,7 +202,7 @@ fun CargoConfigurationCard(
                 cargoType = CargoType.COLD_STORAGE,
                 currentTons = uiState.coldStorageTons,
                 maxTons = uiState.getAvailableTonnageFor(CargoType.COLD_STORAGE),
-                enabled = !uiState.isCargoEditingDisabled,
+                enabled = uiState.canEditCargoType(CargoType.COLD_STORAGE),
                 onValueChange = onCargoUpdate
             )
             
@@ -211,7 +211,7 @@ fun CargoConfigurationCard(
                 cargoType = CargoType.SECURED_CARGO,
                 currentTons = uiState.securedCargoTons,
                 maxTons = uiState.getAvailableTonnageFor(CargoType.SECURED_CARGO),
-                enabled = !uiState.isCargoEditingDisabled,
+                enabled = uiState.canEditCargoType(CargoType.SECURED_CARGO),
                 onValueChange = onCargoUpdate
             )
             
@@ -220,7 +220,7 @@ fun CargoConfigurationCard(
                 cargoType = CargoType.XENO_CARGO,
                 currentTons = uiState.xenoCargoTons,
                 maxTons = uiState.getAvailableTonnageFor(CargoType.XENO_CARGO),
-                enabled = !uiState.isCargoEditingDisabled,
+                enabled = uiState.canEditCargoType(CargoType.XENO_CARGO),
                 onValueChange = onCargoUpdate
             )
         }

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoViewModel.kt
@@ -192,8 +192,8 @@ class CargoViewModel @Inject constructor(
         val currentState = _uiState.value
         val ship = currentState.ship ?: return
         
-        // Don't allow updates if cargo editing is disabled (remaining tonnage <= 0)
-        if (currentState.isCargoEditingDisabled) {
+        // Don't allow updates if this specific cargo type can't be edited
+        if (!currentState.canEditCargoType(cargoType)) {
             return
         }
         

--- a/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoViewModel.kt
+++ b/app/src/main/java/starship/virtualsoundnw/com/ui/cargo/CargoViewModel.kt
@@ -49,6 +49,24 @@ data class CargoUiState(
 ) {
     val ship: StarShip? get() = shipSummary?.ship
     val isCargoEditingDisabled: Boolean get() = shipSummary?.let { it.remainingTonnage <= 0 } ?: false
+    
+    /**
+     * Check if a specific cargo type can be edited when ship is over-tonnage
+     * Allow reducing non-zero cargo types to free up tonnage
+     */
+    fun canEditCargoType(cargoType: CargoType): Boolean {
+        val remainingTonnage = shipSummary?.remainingTonnage ?: 0.0
+        if (remainingTonnage > 0) return true // Normal editing when tonnage available
+        
+        // When over-tonnage, only allow editing cargo types that have current allocation > 0
+        return when (cargoType) {
+            CargoType.CARGO -> cargoTons > 0
+            CargoType.SPARES -> sparesTons > 0
+            CargoType.COLD_STORAGE -> coldStorageTons > 0
+            CargoType.SECURED_CARGO -> securedCargoTons > 0
+            CargoType.XENO_CARGO -> xenoCargoTons > 0
+        }
+    }
     val serviceIntervalMonths: Int get() = shipSummary?.let { summary -> 
         if (summary.ship.tons > 0) {
             val sparesPercentage = (sparesTons.toFloat() / summary.ship.tons) * 100
@@ -65,6 +83,7 @@ data class CargoUiState(
     
     /**
      * Get available tonnage for a specific cargo type
+     * When ship is over-tonnage, only allow reducing current allocations
      */
     fun getAvailableTonnageFor(cargoType: CargoType): Int {
         val currentTotalTonnage = cargoTons + sparesTons + coldStorageTons + securedCargoTons + xenoCargoTons
@@ -76,6 +95,14 @@ data class CargoUiState(
             CargoType.XENO_CARGO -> xenoCargoTons
         }
         
+        val remainingTonnage = shipSummary?.remainingTonnage ?: 0.0
+        
+        // When ship is over-tonnage, only allow reducing current allocation
+        if (remainingTonnage <= 0) {
+            return currentTypeTonnage
+        }
+        
+        // Normal case: ship has available tonnage
         // Special constraint for Spares: maximum 11% of ship tonnage (for service every 12 months)
         if (cargoType == CargoType.SPARES) {
             val maxSparesAllowed = ship?.let { (it.tons * 0.11).toInt() } ?: 0


### PR DESCRIPTION
## Summary
- Fixes issue where cargo sliders were completely locked when ship was over-tonnage (Remaining Tons < 0)
- Now allows users to reduce existing cargo allocations to free up tonnage when ship design exceeds capacity
- Adds `canEditCargoType()` function that enables editing cargo types with current allocations > 0 when over-tonnage
- Modifies `getAvailableTonnageFor()` to limit maximum tonnage to current allocation when over-tonnage
- Updates error message to clarify that existing allocations can be reduced

## Changes
- **CargoViewModel.kt**: Added `canEditCargoType()` function and enhanced `getAvailableTonnageFor()` logic
- **CargoScreen.kt**: Updated all cargo sliders to use new enabling logic and improved error message

## Test plan
- [ ] Create a ship with over-tonnage situation (Remaining Tons < 0)
- [ ] Verify cargo types with 0 allocation remain disabled (sliders locked)
- [ ] Verify cargo types with > 0 allocation become enabled (sliders unlocked)
- [ ] Confirm users can only reduce allocations, not increase them when over-tonnage
- [ ] Test that reducing cargo allocations frees up tonnage correctly
- [ ] Run unit tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)